### PR TITLE
Add missing dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,16 +43,20 @@ setup(
     ],
     test_suite='tests',
     install_requires=[
-        "future",
-        "six",
+        "aenum",
         "click",
-        "networkx",
+        "croniter",
         "funcsigs",
+        "future",
         "fuzzywuzzy",
         "jinja2",
-        "aenum",
         "lxml",
+        "networkx",
+        "OpenDSSDirect.py",
+        "pandas",
         "pytest",
+        "six",
+        "xlrd"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Resolves #2. I took the opportunity to organize the dependencies in alphabetical order. I can revert that to make the diff clearer if needed.