### PR TITLE
There was an space mixed in with tabs on this line. Python3 gave an error

### DIFF
--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -3052,7 +3052,7 @@ section_1_feeder_2,node_1,node_2,ABC
                         continue
                 elif value_type==2: #P and PF are given
                     try:
-                         p,PF=float(settings['value1']), float(settings['value2'])
+                        p,PF=float(settings['value1']), float(settings['value2'])
                         q=p*math.sqrt((1-PF**2)/PF**2)
                     except:
                         print('WARNING:: Skipping load on section {}'.format(sectionID))


### PR DESCRIPTION
Noticed this:
```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    from ditto.readers.cyme.read import reader as Reader
  File "/Users/evert/Documents/gridos/ditto/ditto/readers/cyme/read.py", line 3056
    q=p*math.sqrt((1-PF**2)/PF**2)
                                 ^
TabError: inconsistent use of tabs and spaces in indentation
```