### PR TITLE
Add prefix

### DIFF
--- a/ditto/readers/opendss/read.py
+++ b/ditto/readers/opendss/read.py
@@ -1303,7 +1303,7 @@ Responsible for calling the sub-parsers and logging progress.
 
             #Name
             try:
-                reg_name = name.split('.')[1].lower()
+                reg_name = 'regulator_'+name.split('.')[1].lower()
                 if reg_name not in self.all_object_names:
                     self.all_object_names.append(reg_name)
                 else:


### PR DESCRIPTION
When reading from OpenDSS, regulator objects were having name conflicts with their associated transformers. I suppose this is also linked to #49, but this should solve the name conflicts in the mean time.