### PR TITLE
Json parsers

### DIFF
--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -12,6 +12,7 @@ from ditto.models.node import Node
 from ditto.models.line import Line
 from ditto.models.winding import Winding
 from ditto.models.powertransformer import PowerTransformer
+from ditto.models.regulator import Regulator
 from ditto.models.position import Position
 from ditto.models.wire import Wire
 from ditto.models.phase_winding import PhaseWinding
@@ -97,7 +98,7 @@ Author: Nicolas Gensollen. January 2018
 
         ditto_klasses = [
             'PowerSource', 'Node', 'Line', 'Winding', 'PowerTransformer', 'Position', 'Wire', 'PhaseWinding', 'Load', 'PhaseLoad', 'Capacitor',
-            'PhaseCapacitor', 'Feeder_metadata'
+            'PhaseCapacitor', 'Feeder_metadata', 'Regulator'
         ]
 
         #Create a new empty model

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -24,7 +24,7 @@ from ditto.models.base import Unicode
 from ditto.models.feeder_metadata import Feeder_metadata
 
 
-class Reader:
+class Reader(object):
     '''JSON-->DiTTo Reader class
 
 The reader expects the following format:

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -22,7 +22,7 @@ from ditto.models.phase_capacitor import PhaseCapacitor
 from ditto.models.base import Unicode
 
 
-class reader:
+class Reader:
     '''JSON-->DiTTo Reader class
 
 The reader expects the following format:

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -20,6 +20,7 @@ from ditto.models.phase_load import PhaseLoad
 from ditto.models.capacitor import Capacitor
 from ditto.models.phase_capacitor import PhaseCapacitor
 from ditto.models.base import Unicode
+from ditto.models.feeder_metadata import Feeder_metadata
 
 
 class Reader:
@@ -96,7 +97,7 @@ Author: Nicolas Gensollen. January 2018
 
         ditto_klasses = [
             'PowerSource', 'Node', 'Line', 'Winding', 'PowerTransformer', 'Position', 'Wire', 'PhaseWinding', 'Load', 'PhaseLoad', 'Capacitor',
-            'PhaseCapacitor'
+            'PhaseCapacitor', 'Feeder_metadata'
         ]
 
         #Create a new empty model

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -15,7 +15,7 @@ from ditto.models.phase_load import PhaseLoad
 from ditto.models.phase_capacitor import PhaseCapacitor
 
 
-class Writer:
+class Writer(object):
     '''DiTTo--->JSON Writer class
 
 The writer produce a file with the following format:
@@ -169,6 +169,6 @@ The output file is configured in the constructor.
 
         with open(self.output_path, 'w') as f:
             try:
-                json.dump(_model, f)
+                f.write(json.dumps(_model))
             except:
-                json_tricks.dump(_model,f,allow_nan=True)
+                f.write(json_tricks.dumps(_model,allow_nan=True))

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 from builtins import super, range, zip, round, map
 
 import json
+import json_tricks
 
 from ditto.models.position import Position
 from ditto.models.base import Unicode
@@ -167,4 +168,7 @@ The output file is configured in the constructor.
                 _model[-1][key] = {'klass': str(type(value)).split("'")[1], 'value': value}
 
         with open(self.output_path, 'w') as f:
-            json.dump(_model, f)
+            try:
+                json.dump(_model, f)
+            except:
+                json_tricks.dump(_model,f,allow_nan=True)

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -14,7 +14,7 @@ from ditto.models.phase_load import PhaseLoad
 from ditto.models.phase_capacitor import PhaseCapacitor
 
 
-class writer:
+class Writer:
     '''DiTTo--->JSON Writer class
 
 The writer produce a file with the following format:

--- a/tests/test_json_parsers.py
+++ b/tests/test_json_parsers.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+"""
+test_JSON
+----------------------------------
+
+Tests for JSON parsers.
+"""
+import os
+import six
+import pytest as pt
+from ditto.store import Store
+if six.PY2:
+    from backports import tempfile
+else:
+    import tempfile
+
+current_directory = os.path.realpath(os.path.dirname(__file__))
+
+def test_opendss_to_json():
+    '''Test the JSON writer with OpenDSS models as input.'''
+    from ditto.readers.opendss.read import Reader
+    from ditto.store import Store
+    from ditto.writers.json.write import Writer
+
+    opendss_models=[f for f in os.listdir(os.path.join(current_directory,'data/small_cases/opendss/')) if not f.startswith('.')]
+    for model in opendss_models:
+        m = Store()
+        r = Reader(
+            master_file=os.path.join(current_directory, 'data/small_cases/opendss/{model}/master.dss'.format(model=model)),
+            buscoordinates_file=os.path.join(current_directory, 'data/small_cases/opendss/{model}/buscoord.dss'.format(model=model))
+        )
+        r.parse(m)
+        m.set_names()
+        output_path = tempfile.TemporaryDirectory()
+        w = Writer(output_path=os.path.join(output_path.name,'test.json'))
+        w.write(m)
+
+def test_cyme_to_json():
+    '''Test the JSON writer with CYME models as input.'''
+    from ditto.readers.cyme.read import Reader
+    from ditto.store import Store
+    from ditto.writers.json.write import Writer
+
+    cyme_models=[f for f in os.listdir(os.path.join(current_directory, 'data/small_cases/cyme/')) if not f.startswith('.')]
+    for model in cyme_models:
+        m = Store()
+        r = Reader(data_folder_path=os.path.join(current_directory, 'data/small_cases/cyme',model))
+        r.parse(m)
+        m.set_names()
+        output_path = tempfile.TemporaryDirectory()
+        w = Writer(output_path=os.path.join(output_path.name,'test.json'))
+        w.write(m)
+
+def test_json_reader():
+    '''Test the JSON reader.'''
+    #TODO
+    pass
+
+def test_json_serialize_deserialize():
+    '''Write a model to JSON, read it back in, and test that both models match.'''
+    from ditto.readers.opendss.read import Reader
+    from ditto.store import Store
+    from ditto.writers.json.write import Writer
+    from ditto.readers.json.read import Reader as json_reader
+
+    opendss_models=[f for f in os.listdir(os.path.join(current_directory,'data/small_cases/opendss/')) if not f.startswith('.')]
+    for model in opendss_models:
+        m = Store()
+        r = Reader(
+            master_file=os.path.join(current_directory, 'data/small_cases/opendss/{model}/master.dss'.format(model=model)),
+            buscoordinates_file=os.path.join(current_directory, 'data/small_cases/opendss/{model}/buscoord.dss'.format(model=model))
+        )
+        r.parse(m)
+        m.set_names()
+        w = Writer(output_path='./test.json')
+        w.write(m)
+        jr = json_reader(input_file='./test.json')
+        jr.parse()
+        assert m == jr.model
+    os.remove('./test.json')


### PR DESCRIPTION
Solves issue #60 
Also adresses #48 

One of the tests serializes and deserializes the OpenDSS test cases, and tries to make sure that the models before and after match. 
I'm not 100% satisfied with the function I came up with to test equality (see function ```compare(obj1, obj2)``` in commit 50d227637419c22cd42aecc7c974f1a334ce56e5). If someone has a better solution (or if we already have something testing the equality between 2 models that I didn't see), feel free to give suggestions. ;)