### PR TITLE
Handle condID_N and condID_N1

### DIFF
--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -1770,8 +1770,9 @@ class Reader(AbstractReader):
                 if settings['devicenumber'] in self.concentric_neutral_cable:
                     line_data=self.concentric_neutral_cable[settings['devicenumber']]
                     line_data['type']='balanced_line'
-                elif 'condid_a' in settings and 'condid_b' in settings and 'condid_c' in settings and 'condid_n1' in settings and 'spacingid' in settings:
-                    line_data={'type':'unbalanced_spacing_conf'}
+                elif 'condid_a' in settings and 'condid_b' in settings and 'condid_c' in settings and 'spacingid' in settings:
+                    if 'condid_n' in settings or 'condid_n1' in settings:
+                        line_data={'type':'unbalanced_spacing_conf'}
 
             if line_data is None:
                 if not 'phase' in settings.keys():


### PR DESCRIPTION
Addresses #68.
Voltages were dropping to 0 after the regulator.
Overhead by phase lines were not parsed because ```condID_N``` is used instead of ```condID_N1```.
After this fix, voltages should not drop to 0 for the 13 node feeder. They still look really bad (very low). I will raise an other issue for that since it is more related to validation rather than a bug...