### PR TITLE
Load connected kva

### DIFF
--- a/ditto/metrics/network_analysis.py
+++ b/ditto/metrics/network_analysis.py
@@ -169,6 +169,11 @@ class network_analyzer():
         self.node_feeder_mapping = {}
         self.points = {}
 
+        #This flag indicates whether we should compute the kva density metric using transformer objects
+        #Default is True. If set to False, the `transformer_connected_kva` attribute of load objects will
+        #be used. This enables fair comparison between networks where LV data is missing.
+        self.compute_kva_density_with_transformers = True
+
         self.__substations = [obj for obj in self.model.models if isinstance(obj, PowerTransformer) and obj.is_substation == 1]
 
     def provide_network(self,network):
@@ -756,6 +761,11 @@ class network_analyzer():
             if hasattr(obj, 'num_users') and obj.num_users is not None:
                 self.results[feeder_name]['num_customers'] += obj.num_users
 
+            #If we use the loads to compute the kva distribution...
+            if not self.compute_kva_density_with_transformers:
+                if hasattr(obj, 'transformer_connected_kva') and obj.transformer_connected_kva is not None:
+                    self.results[feeder_name]['sum_distribution_transformer_mva'] += obj.transformer_connected_kva * 10**-6
+
             if hasattr(obj, 'upstream_transformer_name') and obj.upstream_transformer_name is not None:
                 #Number of loads per distribution transformer
                 if obj.upstream_transformer_name in self.results[feeder_name]['num_load_per_transformer']:
@@ -955,8 +965,10 @@ class network_analyzer():
                     obj.windings[0].nominal_voltage!=obj.windings[1].nominal_voltage):
                     self.results[feeder_name]['num_distribution_transformers'] += 1
 
-                    if hasattr(obj.windings[0], 'rated_power') and obj.windings[0].rated_power is not None:
-                        self.results[feeder_name]['sum_distribution_transformer_mva'] += obj.windings[0].rated_power * 10**-6 #DiTTo in va
+                    #If we use the transformers to compute the kva distribution
+                    if self.compute_kva_density_with_transformers:
+                        if hasattr(obj.windings[0], 'rated_power') and obj.windings[0].rated_power is not None:
+                            self.results[feeder_name]['sum_distribution_transformer_mva'] += obj.windings[0].rated_power * 10**-6 #DiTTo in va
 
                     if hasattr(obj.windings[0], 'phase_windings') and obj.windings[0].phase_windings is not None:
                         if len(obj.windings[0].phase_windings) == 1:
@@ -981,10 +993,14 @@ class network_analyzer():
             logger.debug('Could not find feeder for {}'.format(obj.name))
             return None
 
-    def compute_all_metrics_per_feeder(self):
+    def compute_all_metrics_per_feeder(self, **kwargs):
         '''
             Computes all the available metrics for each feeder.
         '''
+        #Enables changing the flag
+        if 'compute_kva_density_with_transformers' in kwargs and isinstance(kwargs['compute_kva_density_with_transformers'], bool):
+            self.compute_kva_density_with_transformers = kwargs['compute_kva_density_with_transformers']
+
         self.transformer_load_mapping=self.get_transformer_load_mapping()
         self.compute_node_line_mapping()
         self.load_distribution = []
@@ -1156,7 +1172,7 @@ class network_analyzer():
                     self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['sum_distribution_transformer_mva'])/float(hull_surf_sqmile)
 
 
-    def compute_all_metrics(self,*args):
+    def compute_all_metrics(self,*args,**kwargs):
         '''
             This function computes all the metrics for the whole network in a way that optimizes performance.
             Instead of calling all the metrics one by one, we loop over the objects only once and update the metrics.
@@ -1167,6 +1183,11 @@ class network_analyzer():
             f_name = args[0]
         else:
             f_name = 'global'
+
+        #Enables changing the flag
+        if 'compute_kva_density_with_transformers' in kwargs and isinstance(kwargs['compute_kva_density_with_transformers'], bool):
+            self.compute_kva_density_with_transformers = kwargs['compute_kva_density_with_transformers']
+
         self.results = {f_name: self.setup_results_data_structure()}
         self.transformer_load_mapping=self.get_transformer_load_mapping()
         self.compute_node_line_mapping()

--- a/ditto/metrics/network_analysis.py
+++ b/ditto/metrics/network_analysis.py
@@ -1153,7 +1153,7 @@ class network_analyzer():
                     self.results[_feeder_ref]['cust_density'] = float(self.results[_feeder_ref]['num_customers'])/float(hull_surf_sqmile)
                     self.results[_feeder_ref]['load_density_kw'] = float(self.results[_feeder_ref]['sum_load_kw'])/float(hull_surf_sqmile)
                     self.results[_feeder_ref]['load_density_kvar'] = float(self.results[_feeder_ref]['sum_load_kvar'])/float(hull_surf_sqmile)
-                    self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['distribution_transformer_total_capacity_MVA'])/float(hull_surf_sqmile)
+                    self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['sum_distribution_transformer_mva'])/float(hull_surf_sqmile)
 
 
     def compute_all_metrics(self,*args):
@@ -1328,7 +1328,7 @@ class network_analyzer():
                 self.results[_feeder_ref]['cust_density'] = float(self.results[_feeder_ref]['num_customers'])/float(hull_surf_sqmile)
                 self.results[_feeder_ref]['load_density_kw'] = float(self.results[_feeder_ref]['sum_load_kw'])/float(hull_surf_sqmile)
                 self.results[_feeder_ref]['load_density_kvar'] = float(self.results[_feeder_ref]['sum_load_kvar'])/float(hull_surf_sqmile)
-                self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['distribution_transformer_total_capacity_MVA'])/float(hull_surf_sqmile)
+                self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['sum_distribution_transformer_mva'])/float(hull_surf_sqmile)
 
 
 

--- a/ditto/metrics/network_analysis.py
+++ b/ditto/metrics/network_analysis.py
@@ -322,7 +322,7 @@ class network_analyzer():
                'sum_load_kvar', 'perct_lv_pha_load_kw', 'perct_lv_phb_load_kw', 'perct_lv_phc_load_kw',
                'num_lv_1ph_loads', 'num_lv_3ph_loads', 'num_mv_3ph_loads', 'avg_num_load_per_transformer',
                'avg_load_pf', 'avg_load_imbalance_by_phase', 'num_customers', 'cust_density',
-               'load_density_kw', 'load_density_kvar',
+               'load_density_kw', 'load_density_kvar', 'kva_density',
 
                #Graph Topology
                'avg_degree', 'avg_path_len', 'diameter'
@@ -1139,6 +1139,8 @@ class network_analyzer():
             self.results[_feeder_ref]['cust_density'] = np.nan
             self.results[_feeder_ref]['load_density_kw'] = np.nan
             self.results[_feeder_ref]['load_density_kvar'] = np.nan
+            self.results[_feeder_ref]['kva_density'] = np.nan
+
             try:
                 _points=np.array(self.points[_feeder_ref])
             except KeyError:
@@ -1151,6 +1153,7 @@ class network_analyzer():
                     self.results[_feeder_ref]['cust_density'] = float(self.results[_feeder_ref]['num_customers'])/float(hull_surf_sqmile)
                     self.results[_feeder_ref]['load_density_kw'] = float(self.results[_feeder_ref]['sum_load_kw'])/float(hull_surf_sqmile)
                     self.results[_feeder_ref]['load_density_kvar'] = float(self.results[_feeder_ref]['sum_load_kvar'])/float(hull_surf_sqmile)
+                    self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['distribution_transformer_total_capacity_MVA'])/float(hull_surf_sqmile)
 
 
     def compute_all_metrics(self,*args):
@@ -1311,6 +1314,8 @@ class network_analyzer():
         self.results[_feeder_ref]['cust_density'] = np.nan
         self.results[_feeder_ref]['load_density_kw'] = np.nan
         self.results[_feeder_ref]['load_density_kvar'] = np.nan
+        self.results[_feeder_ref]['kva_density'] = np.nan
+
         try:
             _points=np.array(self.points[_feeder_ref])
         except KeyError:
@@ -1323,6 +1328,8 @@ class network_analyzer():
                 self.results[_feeder_ref]['cust_density'] = float(self.results[_feeder_ref]['num_customers'])/float(hull_surf_sqmile)
                 self.results[_feeder_ref]['load_density_kw'] = float(self.results[_feeder_ref]['sum_load_kw'])/float(hull_surf_sqmile)
                 self.results[_feeder_ref]['load_density_kvar'] = float(self.results[_feeder_ref]['sum_load_kvar'])/float(hull_surf_sqmile)
+                self.results[_feeder_ref]['kva_density'] = float(10**3*self.results[_feeder_ref]['distribution_transformer_total_capacity_MVA'])/float(hull_surf_sqmile)
+
 
 
     def number_of_regulators(self):

--- a/ditto/models/load.py
+++ b/ditto/models/load.py
@@ -55,5 +55,8 @@ class Load(DiTToHasTraits):
     #Modification: Nicolas (December 2017)
     upstream_transformer_name = Unicode(help='''The name of the distribution transformer which serves this load''', default_value=None)
 
+    #Modification: Nicolas (May 2018)
+    transformer_connected_kva = Float(help='''KVA of the distribution transformer which serves this load.''', default_value=None)
+
     def build(self, model):
         self._model = model

--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -3329,6 +3329,11 @@ class Reader(AbstractReader):
             else:
                 load_data={}
 
+            if 'connectedkva' in settings:
+                connectedkva = float(settings['connectedkva'])
+            else:
+                connectedkva = None
+
             if 'valuetype' in settings:
                 value_type=int(settings['valuetype'])
 
@@ -3394,6 +3399,18 @@ class Reader(AbstractReader):
                     except:
                         pass
 
+                    try:
+                        if not fusion:
+                            if connectedkva is not None:                            
+                                api_load.transformer_connected_kva = connectedkva
+                        elif connectedkva is not None:
+                            if api_load.transformer_connected_kva is None:
+                                api_load.transformer_connected_kva = connectedkva
+                            else:
+                                api_load.transformer_connected_kva += connectedkva            
+                    except:
+                        pass
+                    
                     try:
                         if not fusion:
                             api_load.connection_type=self.connection_configuration_mapping(load_data['connection'])


### PR DESCRIPTION
Adresses #80
- Load objects have a ```transformer_connected_kva``` attribute
- When computing the ```total_demand``` and the ```load_density``` metrics, this kva value is used whenever ```P=0``` AND ```Q=0```
- Add a ```kva_density``` metric that shows the distribution transformer kva density (but does not capture MV loads)
