### PR TITLE
Add ditto cli

### DIFF
--- a/docs/cli-examples.md
+++ b/docs/cli-examples.md
@@ -13,27 +13,27 @@ Conversion examples with more advanced features can be found in the examples sub
 DiTTo supports a command line interface (CLI) to quickly convert a model. The command is simply:
 
 ```bash
-ditto convert
+$ ditto-cli convert
 ```
 
 Help can be obtained using:
 
 ```bash
-ditto convert --help
+$ ditto-cli convert --help
 ```
 
 #### From and To
 
-The options ```—from``` and ```—to``` are easy to understand, they just tell ```ditto convert``` what format is expected for the input, and what format is desired for the output. If we want to convert from opendss to gridlabd, we can use:
+The options ```—from``` and ```—to``` are easy to understand, they just tell ```ditto-cli convert``` what format is expected for the input, and what format is desired for the output. If we want to convert from opendss to gridlabd, we can use:
 
 ```bash
-ditto convert --from opendss --to gridlabd
+$ ditto-cli convert --from opendss --to gridlabd
 ```
 
 Note that, we can use short-cut names for the format like:
 
 ```bash
-ditto convert --from dss --to glm
+$ ditto-cli convert --from dss --to glm
 ```
 
 #### Input
@@ -43,7 +43,7 @@ In addition to the formats, we need to provide some input to DiTTo. The main iss
 To be consistent, the CLI accepts only one file whatever the format. If we have a gridlabd model entirely stored in a file called ```model.glm``` we can use:
 
 ```bash
-ditto convert --from glm --input ./model.glm --to cyme
+$ ditto-cli convert --from glm --input ./model.glm --to cyme
 ```
 
 For formats like Cyme where we need multiple input files, we need to write a simple JSON configuration file:
@@ -61,15 +61,15 @@ For formats like Cyme where we need multiple input files, we need to write a sim
 Which results in the following command:
 
 ```bash
-ditto convert --from cyme --input ./config.json --to dss
+$ ditto-cli convert --from cyme --input ./config.json --to dss
 ```
 
 #### Output
 
-Finally, we need to tell ```ditto convert``` where to write the output. This is done with the ```—output``` option. Make sure to provide the path to the folder you want the files to be written in. For example, if we want to output in a folder named ```./results``` we do the following:
+Finally, we need to tell ```ditto-cli convert``` where to write the output. This is done with the ```—output``` option. Make sure to provide the path to the folder you want the files to be written in. For example, if we want to output in a folder named ```./results``` we do the following:
 
 ```bash
-ditto convert --from cyme --input ./config.json --to dss --output ./results/
+$ ditto-cli convert --from cyme --input ./config.json --to dss --output ./results/
 ```
 
 ### Examples
@@ -79,7 +79,7 @@ ditto convert --from cyme --input ./config.json --to dss --output ./results/
 Run the following command:
 
 ```bash
-ditto convert --input ../tests/data/gridlabd/4node.glm --from glm --to dss --output ./
+$ ditto-cli convert --input ../tests/data/gridlabd/4node.glm --from glm --to dss --output ./
 ```
 
 #### Convert the IEEE 13 node from OpenDSS to CYME
@@ -87,7 +87,7 @@ ditto convert --input ../tests/data/gridlabd/4node.glm --from glm --to dss --out
 Here, we use the configuration file: ```ditto/examples/ieee_13node_opendss_input.json```:
 
 ```bash
-ditto convert --input ../examples/ieee_13node_opendss_input.json --from opendss --to cyme --output ./
+$ ditto-cli convert --input ../examples/ieee_13node_opendss_input.json --from opendss --to cyme --output ./
 ```
 
 ### Method 2: Writing a script

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ $ python ieee_8500_opendss_to_cyme.py
 Alternatively, you can use the CLI and the configuration file ```ieee_8500_opendss_to_cyme.json```. Open a terminal and run:
 
 ```bash
-$ ditto convert --from dss --input ieee_8500_to_cyme.json --to cyme --output .
+$ ditto-cli convert --from dss --input ieee_8500_to_cyme.json --to cyme --output .
 ```
 
 
@@ -32,7 +32,7 @@ $ python epri_j1_opendss_to_cyme.py
 Alternatively, you can use the CLI and the configuration file ```epri_j1_opendss_to_cyme.json```. Open a terminal and run:
 
 ```bash
-ditto convert --from dss --input epri_j1_opendss_to_cyme.json --to cyme --output .
+$ ditto-cli convert --from dss --input epri_j1_opendss_to_cyme.json --to cyme --output .
 ```
 
 ### Example 3: IEEE 123
@@ -48,7 +48,7 @@ $ python ieee_123node_gridlabd_to_opendss.py
 Alternatively, you can use the CLI:
 
 ```bash
-ditto convert --from glm --input ../tests/data/big_cases/gridlabd/ieee_123node/123_node.glm --to dss --output .
+$ ditto-cli convert --from glm --input ../tests/data/big_cases/gridlabd/ieee_123node/123_node.glm --to dss --output .
 ```
 
 #### CYME —> OpenDSS
@@ -62,6 +62,6 @@ $ python ieee_123node_cyme_to_opendss.py
 Alternatively, you can use the CLI and the configuration file ```ieee_123node_cyme_to_opendss.json```. Open a terminal and run:
 
 ```bash
-$ ditto convert --from cyme --input ieee_123node_cyme_to_opendss.json --to dss --output .
+$ ditto-cli convert --from cyme --input ieee_123node_cyme_to_opendss.json --to dss --output .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
             "gridlabd=ditto.readers.gridlabd:GridLABDReader",
             "opendss=ditto.readers.opendss:OpenDSSReader",
             "cyme=ditto.readers.cyme:CymeReader",
-	    "demo=ditto.readers.demo:DemoReader"
+            "demo=ditto.readers.demo:DemoReader"
         ],
         "ditto.writers": [
             "gridlabd=ditto.writers.gridlabd:GridLABDWriter",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ setup(
     packages=find_packages(),
     package_dir={'ditto': 'ditto'},
     entry_points={
-        "console_scripts": ["ditto=ditto.cli:cli"],
+        "console_scripts": [
+            "ditto=ditto.cli:cli",
+            "ditto-cli=ditto.cli:cli"
+        ],
         "ditto.readers": [
             "gridlabd=ditto.readers.gridlabd:GridLABDReader",
             "opendss=ditto.readers.opendss:OpenDSSReader",

--- a/tests/test_ditto_cli.py
+++ b/tests/test_ditto_cli.py
@@ -15,7 +15,7 @@ def test_opendss_to_gridlabd_cli():
 
     output_path = tempfile.TemporaryDirectory()
     print(output_path.name)
-    p = subprocess.Popen(shlex.split(""" ditto convert --from="opendss" --to="gridlabd" --input="./tests/data/small_cases/opendss/ieee_13node/master.dss" --output="{}" """.format(output_path.name).strip()))
+    p = subprocess.Popen(shlex.split(""" ditto-cli convert --from="opendss" --to="gridlabd" --input="./tests/data/small_cases/opendss/ieee_13node/master.dss" --output="{}" """.format(output_path.name).strip()))
     p.wait()
     with open(os.path.join(output_path.name, "Model.glm")) as f:
         output = f.read().strip()
@@ -32,7 +32,7 @@ def test_opendss_to_gridlabd_cli():
 def test_gridlabd_to_opendss_cli():
 
     output_path = tempfile.TemporaryDirectory()
-    p = subprocess.Popen(shlex.split(""" ditto convert --from="gridlabd" --to="opendss" --input="./tests/data/small_cases/gridlabd/4node.glm" --output="{}" """.format(output_path.name).strip()))
+    p = subprocess.Popen(shlex.split(""" ditto-cli convert --from="gridlabd" --to="opendss" --input="./tests/data/small_cases/gridlabd/4node.glm" --output="{}" """.format(output_path.name).strip()))
     p.wait()
     if p.returncode != 0:
         raise Exception("Error in ditto cli: {}".format(p.returncode))


### PR DESCRIPTION
Fixes #86. 

Adds `ditto-cli` that does the same thing as `ditto`. We can deprecate `ditto` in a future version if required.