### PR TITLE
Cli jsonize feature

### DIFF
--- a/ditto/cli.py
+++ b/ditto/cli.py
@@ -62,7 +62,7 @@ def convert(ctx, **kwargs):
     from_reader_name = kwargs["from"]
     to_writer_name = kwargs["to"]
     
-    if "jsonize" in kwargs:
+    if kwargs["jsonize"] is not None:
         Converter(
             registered_reader_class=registered_readers[from_reader_name],
             registered_writer_class=registered_writers[to_writer_name],

--- a/ditto/cli.py
+++ b/ditto/cli.py
@@ -29,6 +29,7 @@ def cli(ctx, verbose):
 @click.option("--output", type=click.Path(exists=True), help="Path to output file")
 @click.option("--from", help="Convert from OpenDSS, Cyme, GridLAB-D, Demo")
 @click.option("--to", help="Convert to OpenDSS, Cyme, GridLAB-D, Demo")
+@click.option("--jsonize", type=click.Path(exists=True), help="Serialize the DiTTo representation to the specified path")
 @click.pass_context
 def convert(ctx, **kwargs):
     """ Convert from one type to another"""
@@ -60,12 +61,23 @@ def convert(ctx, **kwargs):
 
     from_reader_name = kwargs["from"]
     to_writer_name = kwargs["to"]
-    Converter(
-        registered_reader_class=registered_readers[from_reader_name],
-        registered_writer_class=registered_writers[to_writer_name],
-        input_path=kwargs["input"],
-        output_path=kwargs["output"],
-    ).convert()
+    
+    if "jsonize" in kwargs:
+        Converter(
+            registered_reader_class=registered_readers[from_reader_name],
+            registered_writer_class=registered_writers[to_writer_name],
+            input_path=kwargs["input"],
+            output_path=kwargs["output"],
+            json_path=kwargs["jsonize"],
+            registered_json_writer_class=registered_writers['json']
+        ).convert()
+    else:
+        Converter(
+            registered_reader_class=registered_readers[from_reader_name],
+            registered_writer_class=registered_writers[to_writer_name],
+            input_path=kwargs["input"],
+            output_path=kwargs["output"],
+        ).convert()
 
     sys.exit(0)
 

--- a/ditto/converter.py
+++ b/ditto/converter.py
@@ -33,7 +33,7 @@ class Converter(object):
     Author: Nicolas Gensollen. October 2017
     '''
 
-    def __init__(self, registered_reader_class, registered_writer_class, input_path, output_path, verbose=True):
+    def __init__(self, registered_reader_class, registered_writer_class, input_path, output_path, verbose=True, **kwargs):
         '''Converter class CONSTRUCTOR.'''
 
         self.reader_class = registered_reader_class
@@ -53,6 +53,14 @@ class Converter(object):
         # TODO: check if this is in the registered list
         self._from = registered_reader_class.format_name
         self._to = registered_writer_class.format_name
+
+        #Serialize the DiTTo model before writing it out.
+        if "json_path" in kwargs and "registered_json_writer_class" in kwargs:
+            self.jsonize = True
+            self.json_path = kwargs['json_path']
+            self.json_writer_class = kwargs['registered_json_writer_class']
+        else:
+            self.jsonize = False
 
         self.verbose = verbose
 
@@ -168,6 +176,10 @@ class Converter(object):
         self.configure_writer(output)
 
         self.reader.parse(self.m)
+
+        if self.jsonize:
+            self.json_writer = self.json_writer_class(output_path=self.json_path)
+            self.json_writer.write(self.m)
 
         self.writer.write(self.m, verbose=self.verbose)
 

--- a/ditto/readers/json/__init__.py
+++ b/ditto/readers/json/__init__.py
@@ -1,0 +1,1 @@
+from .read import Reader as JsonReader

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -6,6 +6,7 @@ from builtins import super, range, zip, round, map
 import json
 import numpy
 
+from ditto.readers.abstract_reader import AbstractReader
 from ditto.store import Store
 from ditto.models.power_source import PowerSource
 from ditto.models.node import Node
@@ -24,7 +25,7 @@ from ditto.models.base import Unicode
 from ditto.models.feeder_metadata import Feeder_metadata
 
 
-class Reader(object):
+class Reader(AbstractReader):
     '''JSON-->DiTTo Reader class
 
 The reader expects the following format:

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -78,6 +78,7 @@ object_1={'klass':'PowerTransformer',
 Author: Nicolas Gensollen. January 2018
 
 '''
+    register_names = ["json", "Json", "JSON"]
 
     def __init__(self, **kwargs):
         '''Class CONSTRUCTOR

--- a/ditto/writers/json/__init__.py
+++ b/ditto/writers/json/__init__.py
@@ -1,0 +1,1 @@
+from .write import Writer as JsonWriter

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 from builtins import super, range, zip, round, map
 
+import os
 import json
 import json_tricks
 
@@ -79,7 +80,12 @@ Author: Nicolas Gensollen. January 2018.
         if 'output_path' in kwargs:
             self.output_path = kwargs['output_path']
         else:
-            self.output_path = './out.json'
+            self.output_path = './'
+
+        if 'filename' in kwargs:
+            self.filename = kwargs['filename']
+        else:
+            self.filename = 'Model.json'
 
     def write(self, model):
         '''Write a given DiTTo model to a JSON file.
@@ -169,7 +175,7 @@ The output file is configured in the constructor.
 
                 _model[-1][key] = {'klass': str(type(value)).split("'")[1], 'value': value}
 
-        with open(self.output_path, 'w') as f:
+        with open(os.path.join(self.output_path,self.filename), 'w') as f:
             try:
                 f.write(json.dumps(_model))
             except:

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -69,7 +69,8 @@ object_1={'klass':'PowerTransformer',
 Author: Nicolas Gensollen. January 2018.
 
 '''
-
+    register_names = ["json", "Json", "JSON"]
+    
     def __init__(self, **kwargs):
         '''Class CONSTRUCTOR
 

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -6,6 +6,7 @@ from builtins import super, range, zip, round, map
 import json
 import json_tricks
 
+from ditto.writers.abstract_writer import AbstractWriter
 from ditto.models.position import Position
 from ditto.models.base import Unicode
 from ditto.models.wire import Wire
@@ -15,7 +16,7 @@ from ditto.models.phase_load import PhaseLoad
 from ditto.models.phase_capacitor import PhaseCapacitor
 
 
-class Writer(object):
+class Writer(AbstractWriter):
     '''DiTTo--->JSON Writer class
 
 The writer produce a file with the following format:

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,14 @@ setup(
             "opendss=ditto.readers.opendss:OpenDSSReader",
             "cyme=ditto.readers.cyme:CymeReader",
             "demo=ditto.readers.demo:DemoReader"
+            "json=ditto.readers.json:JsonReader"
         ],
         "ditto.writers": [
             "gridlabd=ditto.writers.gridlabd:GridLABDWriter",
             "opendss=ditto.writers.opendss:OpenDSSWriter",
             "cyme=ditto.writers.cyme:CymeWriter",
-            "demo=ditto.writers.demo:DemoWriter"
+            "demo=ditto.writers.demo:DemoWriter",
+            "json=ditto.writers.json:JsonWriter"
         ],
     },
     include_package_data=True,

--- a/tests/test_json_parsers.py
+++ b/tests/test_json_parsers.py
@@ -33,7 +33,7 @@ def test_opendss_to_json():
         r.parse(m)
         m.set_names()
         output_path = tempfile.TemporaryDirectory()
-        w = Writer(output_path=os.path.join(output_path.name,'test.json'))
+        w = Writer(output_path=output_path.name)
         w.write(m)
 
 def test_cyme_to_json():
@@ -49,7 +49,7 @@ def test_cyme_to_json():
         r.parse(m)
         m.set_names()
         output_path = tempfile.TemporaryDirectory()
-        w = Writer(output_path=os.path.join(output_path.name,'test.json'))
+        w = Writer(output_path=output_path.name)
         w.write(m)
 
 def test_json_reader():
@@ -74,9 +74,9 @@ def test_json_serialize_deserialize():
         )
         r.parse(m)
         m.set_names()
-        w = Writer(output_path='./test.json')
+        w = Writer(output_path='./')
         w.write(m)
-        jr = json_reader(input_file='./test.json')
+        jr = json_reader(input_file='./Model.json')
         jr.parse()
         jr.model.set_names()
 
@@ -90,7 +90,7 @@ def test_json_serialize_deserialize():
                 obj = m[json_obj.name]
                 assert compare(json_obj,obj)
 
-        os.remove('./test.json')
+        os.remove('./Model.json')
 
 
 def compare(obj1, obj2):


### PR DESCRIPTION
When converting from one format to another using ```ditto-cli convert``` it might be nice to also save the DiTTo model in Json format at the same time.

This implements this functionality through the ```jsonize``` option.

Ex:
```bash
$ ditto-cli convert --from dss --to glm --input ./tests/data/small_cases/opendss/ieee_13node/master.dss --output . --jsonize .
``` 