### PR TITLE
Metrics cli

### DIFF
--- a/ditto/cli.py
+++ b/ditto/cli.py
@@ -50,12 +50,17 @@ def metric(ctx, **kwargs):
 
     from_reader_name = kwargs["from"]
 
-    MetricComputer(registered_reader_class=registered_readers[from_reader_name] ,
-                   input_path=kwargs["input"] ,
-                   output_format=kwargs["to"] ,
-                   output_path=kwargs["output"] ,
-                   by_feeder=kwargs["feeder"]).compute()
-    sys.exit(0)
+    try:
+        MetricComputer(registered_reader_class=registered_readers[from_reader_name] ,
+                       input_path=kwargs["input"] ,
+                       output_format=kwargs["to"] ,
+                       output_path=kwargs["output"] ,
+                       by_feeder=kwargs["feeder"]).compute()
+    except Exception as e:
+        # TODO: discuss whether we should raise exception here?
+        sys.exit(1) # TODO: Set error code based on exception
+    else:
+        sys.exit(0)
 
 @cli.command()
 @click.option("--input", type=click.Path(exists=True), help="Path to input file")

--- a/ditto/converter.py
+++ b/ditto/converter.py
@@ -38,6 +38,9 @@ class Converter(object):
 
         self.reader_class = registered_reader_class
 
+        if registered_writer_class is None:
+            logger.warning('Writer class is set to None')
+
         self.writer_class = registered_writer_class
 
         #If the file provided is a JSON file, a configuration file is assumed
@@ -52,7 +55,10 @@ class Converter(object):
 
         # TODO: check if this is in the registered list
         self._from = registered_reader_class.format_name
-        self._to = registered_writer_class.format_name
+        if registered_writer_class is not None:
+            self._to = registered_writer_class.format_name
+        else:
+            self._to = None
 
         #Serialize the DiTTo model before writing it out.
         if "json_path" in kwargs and "registered_json_writer_class" in kwargs:
@@ -157,8 +163,11 @@ class Converter(object):
     def configure_writer(self, outputs):
         '''Configure the writer.'''
 
-        logger.debug("Using Writer {} with outputs {}".format(self.writer_class, outputs))
-        self.writer=self.writer_class(**outputs)
+        if self.writer_class is not None:
+            logger.debug("Using Writer {} with outputs {}".format(self.writer_class, outputs))
+            self.writer=self.writer_class(**outputs)
+        else:
+            logger.error("Cannot configure the writer because Writer class is None.")
 
     def convert(self):
         '''Run the conversion: from_format--->DiTTo--->to_format on all the feeders in feeder_list.'''

--- a/ditto/metric_computer.py
+++ b/ditto/metric_computer.py
@@ -19,7 +19,7 @@ class MetricComputer(Converter):
         self.by_feeder = by_feeder
         self.output_format = output_format
         #Call super
-        Converter.__init__(self, registered_reader_class, None, input_path, output_path, verbose=True, **kwargs)
+        super(MetricComputer, self).__init__(registered_reader_class, None, input_path, output_path, verbose=True, **kwargs)
 
     def convert(self):
         '''Cannot call convert.'''

--- a/ditto/metric_computer.py
+++ b/ditto/metric_computer.py
@@ -1,0 +1,50 @@
+import os
+import datetime
+import traceback
+import json
+
+import logging
+
+from .store import Store
+from .converter import Converter
+from .metrics.network_analysis import network_analyzer
+
+logger = logging.getLogger(__name__)
+
+class MetricComputer(Converter):
+    '''TODO'''
+
+    def __init__(self, registered_reader_class, input_path, output_format, output_path, by_feeder, verbose=True, **kwargs):
+        '''MetricComputer class CONSTRUCTOR.'''
+        self.by_feeder = by_feeder
+        self.output_format = output_format
+        #Call super
+        Converter.__init__(self, registered_reader_class, None, input_path, output_path, verbose=True, **kwargs)
+
+    def convert(self):
+        '''Cannot call convert.'''
+        raise NotImplementedError("MetricComputer cannot convert. Use Converter instead.")
+
+    def compute(self):
+        '''Compute the metrics'''
+        inputs = self.get_inputs(self.feeder)
+
+        self.configure_reader(inputs)
+        self.reader.parse(self.m)
+
+        self.net = network_analyzer(self.m)
+        self.net.model.set_names()
+        #If we compute the metrics per feeder, we need to have the objects taged with their feeder_names
+        if self.by_feeder:
+        #Split the network into feeders (assumes objects have been taged)
+            self.net.split_network_into_feeders()
+            self.net.compute_all_metrics_per_feeder()
+        else:
+            self.net.compute_all_metrics()
+
+        #Export to the required format
+        if self.output_format.lower() == 'json':
+            self.net.export_json(os.path.join(self.output_path,'metrics.json'))
+        elif self.output_format.lower() in ['xlsx','excel','xls']:
+            self.net.export(os.path.join(self.output_path,'metrics.xlsx'))
+

--- a/tests/read_dss_13node.json
+++ b/tests/read_dss_13node.json
@@ -1,0 +1,2 @@
+{"master_file": "./tests/data/small_cases/opendss/ieee_13node/master.dss",
+ "buscoordinates_file": "./tests/data/small_cases/opendss/ieee_13node/buscoord.dss"}

--- a/tests/test_ditto_cli.py
+++ b/tests/test_ditto_cli.py
@@ -37,3 +37,12 @@ def test_gridlabd_to_opendss_cli():
     if p.returncode != 0:
         raise Exception("Error in ditto cli: {}".format(p.returncode))
 
+def test_metric_computation_cli():
+    '''Tests metric computation from command line interface
+    TODO: Add better tests that check the metric values and compare them with ground truth.
+    '''
+    output_path = tempfile.TemporaryDirectory()
+    p = subprocess.Popen(shlex.split(""" ditto-cli metric --from="dss" --to="xlsx" --input="./tests/read_dss_13node.json" --feeder=False --output="{}" """.format(output_path.name).strip()))
+    p.wait()
+    if p.returncode != 0:
+        raise Exception("Error in ditto cli: {}".format(p.returncode))


### PR DESCRIPTION
Enables simple metric computation from command line (see #17)

Basically read from some format (OpenDSS, CYME, JSON,...), compute the metrics, and output the metrics to Excel or JSON.

No post-processing possible yet...

**Example:**
```bash
$ ditto-cli metric --from dss --input ./config.json --output . --to xlsx --feeder False
```

where ```config.json``` is:

```json
 {"master_file": "./tests/data/small_cases/opendss/ieee_13node/master.dss",
   "buscoordinates_file": "./tests/data/small_cases/opendss/ieee_13node/buscoord.dss"}
```

**Help:**
```bash
$ ditto-cli metric --help                                                                                                                                        
Usage: ditto-cli metric [OPTIONS]

  Compute metrics

Options:
  --input PATH      Path to input file
  --from TEXT       Convert from OpenDSS, Cyme, Gridlab-D, Demo, JSON
  --output PATH     Path to the metrics output file
  --to TEXT         Format for the metrics output file. xlsx or json
  --feeder BOOLEAN  If True computes metrics per feeder. Otherwise, compute
                    metrics at the system level.
  --help            Show this message and exit.
```

This is pretty basic but provides something to improve from.

@kdheepak, @tarekelgindy, let me know if you're OK with the implementation or if you have some ideas to improve this.