### PR TITLE
Add is_substation to objects

### DIFF
--- a/ditto/models/capacitor.py
+++ b/ditto/models/capacitor.py
@@ -68,5 +68,8 @@ class Capacitor(DiTToHasTraits):
     substation_name = Unicode(help='''The name of the substation to which the object is connected.''', default=None)
     feeder_name = Unicode(help='''The name of the feeder the object is on.''', default=None)
 
+    #Modification: Nicolas (May 2018)
+    is_substation = Int(help='''Flag that indicates wheter the element is inside a substation or not.''', default_value=0)
+
     def build(self, model):
         self._model = model

--- a/ditto/models/line.py
+++ b/ditto/models/line.py
@@ -76,6 +76,9 @@ class Line(DiTToHasTraits):
     #Modification: Nicolas (March 2018)
     nameclass = Unicode(help='''Nameclass of the line object.''', default_value=None)
 
+    #Modification: Nicolas (May 2018)
+    is_substation = Int(help='''Flag that indicates wheter the element is inside a substation or not.''', default_value=0)
+
     def build(
         self,
         model,

--- a/ditto/models/load.py
+++ b/ditto/models/load.py
@@ -58,5 +58,9 @@ class Load(DiTToHasTraits):
     #Modification: Nicolas (May 2018)
     transformer_connected_kva = Float(help='''KVA of the distribution transformer which serves this load.''', default_value=None)
 
+    #Modification: Nicolas (May 2018)
+    is_substation = Int(help='''Flag that indicates wheter the element is inside a substation or not.''', default_value=0)
+
+
     def build(self, model):
         self._model = model

--- a/ditto/models/node.py
+++ b/ditto/models/node.py
@@ -34,6 +34,9 @@ class Node(DiTToHasTraits):
     # Support for substation connection points. These identify if the node connects the substation to a feeder or high voltage source
     is_substation_connection = Int(help='''1 if the node connects from inside a substation to outside, 0 otherwise.''', default=None)
 
+    #Modification: Nicolas (May 2018)
+    is_substation = Int(help='''Flag that indicates wheter the element is inside a substation or not.''', default_value=0)
+
     def build(self, model, Asset=None, ConnectivityNode=None, Location=None):
 
         self._model = model

--- a/ditto/models/powertransformer.py
+++ b/ditto/models/powertransformer.py
@@ -47,7 +47,7 @@ class PowerTransformer(DiTToHasTraits):
     is_center_tap = Int(help='''Set to 1 if the transformer is a center tap transformer''', default=0)
 
     #Modification: Nicolas (December 2017)
-    is_substation = Int(help='''Set to 1 if the transformer is a substation''', default=0)
+    is_substation = Int(help='''Set to 1 if the transformer is a substation or is inside a substation''', default=0)
 
     #Modification: Nicolas (December 2017)
     #Multiple feeder support. Each element keeps track of the name of the substation it is connected to, as well as the name of the feeder.

--- a/ditto/models/regulator.py
+++ b/ditto/models/regulator.py
@@ -63,6 +63,8 @@ class Regulator(DiTToHasTraits):
     #Modification: Tarek (April 2018)
     setpoint = Float(help='''The percentage p.u. voltage setpoint of the regulator''', default_value=None)
 
+    #Modification: Nicolas (May 2018)
+    is_substation = Int(help='''Flag that indicates wheter the element is inside a substation or not.''', default_value=0)
 
     def build(self, model):
         self._model = model

--- a/ditto/models/storage.py
+++ b/ditto/models/storage.py
@@ -30,6 +30,9 @@ class Storage(DiTToHasTraits):
     substation_name        = Unicode(                     help='''The name of the substation to which the object is connected.''', default=None)
     feeder_name            = Unicode(                     help='''The name of the feeder the object is on.''', default=None)
 
+    #Modification: Nicolas (May 2018)
+    is_substation = Int(help='''Flag that indicates wheter the element is inside a substation or not.''', default_value=0)
+
     def build(self, model):
         """
         TODO...


### PR DESCRIPTION
Add the ```is_substation``` attribute to all the objects that have ```feeder_name``` and ```substation_name```.

Note that ```PowerTransformer``` objects already had a ```is_substation``` attribute. I changed only the help text for this. The attribute will be 1 if the transformer is representing a substation or is inside a substation. I believe this should be fine.