### PR TITLE
Replace fuse_limit with interrupting_rating in wire model (more generic)

### DIFF
--- a/ditto/models/wire.py
+++ b/ditto/models/wire.py
@@ -45,11 +45,13 @@ class Wire(DiTToHasTraits):
         default_value=None,
     )
     is_open = Int(
-        help="""This flag indicates whether or not the line is open (if it is a switch/fuse)""",
+        help="""This flag indicates whether or not the line is open (if it is a switch/fuse/breaker/recloser/sectionalizer/network protector).""",
         default_value=None,
     )
-    fuse_limit = Float(
-        help="""The maximum current that can pass through the wire before the fuse blows""",
+    # Modification: Nicolas Gensollen (June 2018)
+    # fuse_limit --> interrupting_rating (more generic)
+    interrupting_rating = Float(
+        help="""The maximum current that can pass through the wire before the equipment disconnects.""",
         default_value=None,
     )
     concentric_neutral_gmr = Float(
@@ -89,10 +91,6 @@ class Wire(DiTToHasTraits):
     is_network_protector = Int(
         help="""This flag indicates whether or not this wire is also a network protector.""",
         default_value=0,
-    )
-    network_protector_limit = Float(
-        help="""The maximum current before the network protector disconnects.""",
-        default_value=None,
     )
 
     def build(self, model):


### PR DESCRIPTION
This changes the wire attribute ```fuse_limit``` to ```interrupting_rating``` such that all elements having a maximum current which disconnects them (breaker, network protectors...) use the same attribute.

@tarekelgindy, I had a look at the readers and writers and it seems that nobody ever touched ```fuse_limit``` which is good for this PR but a little concerning...