### PR TITLE
Add is_center_tap and center_tap_perct to Load model.

### DIFF
--- a/ditto/models/load.py
+++ b/ditto/models/load.py
@@ -113,5 +113,15 @@ class Load(DiTToHasTraits):
         default_value=0,
     )
 
+    # Modification: Nicolas (July 2018)
+    is_center_tap = Int(
+        help="""Flag that indicates whether the element is a center tap load or not.""",
+        default_value=0,
+    )
+    center_tap_perct = Float(
+        help="""Percentage of the load between active 1 and neutral. Should be a float between 0 and 1. The percentage of the load between neutral and active 2 will be 1 - center_tap_perct.""",
+        default_value=None,
+    )
+
     def build(self, model):
         self._model = model


### PR DESCRIPTION
@tarekelgindy, here is a suggestion to deal with center tap loads. Basically, I added ```is_center_tap```  and ```center_tap_perct``` to ```Load```.
I think this should be enough to implement the post-processing we talked about.
Let me know if you have other suggestions for this.