### PR TITLE
PowerSource-->Photovoltaic

### DIFF
--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -11,6 +11,7 @@ import numpy
 from ditto.readers.abstract_reader import AbstractReader
 from ditto.store import Store
 from ditto.models.power_source import PowerSource
+from ditto.models.photovoltaic import Photovoltaic
 from ditto.models.node import Node
 from ditto.models.line import Line
 from ditto.models.winding import Winding
@@ -97,6 +98,7 @@ class Reader(AbstractReader):
 
         ditto_klasses = [
             "PowerSource",
+            "Photovoltaic",
             "Node",
             "Line",
             "Winding",

--- a/ditto/readers/synergi/read.py
+++ b/ditto/readers/synergi/read.py
@@ -29,6 +29,7 @@ from ditto.models.powertransformer import PowerTransformer
 from ditto.models.winding import Winding
 from ditto.models.phase_winding import PhaseWinding
 from ditto.models.power_source import PowerSource
+from ditto.models.photovoltaic import Photovoltaic
 from ditto.models.position import Position
 from ditto.models.base import Unicode
 
@@ -1394,8 +1395,8 @@ class Reader(AbstractReader):
 
             if PVGenType[i] == "PhotoVoltaic":
 
-                # Create a PowerSource object
-                api_PV = PowerSource(model)
+                # Create a Photovoltaic object
+                api_PV = Photovoltaic(model)
 
                 # Set the name
                 api_PV.name = obj.replace(" ", "_").lower()
@@ -1441,8 +1442,8 @@ class Reader(AbstractReader):
 
             if Count is not None and GeneratorTypeDev[Count] == "PV":
 
-                # Create a PowerSource DiTTo object
-                api_PV = PowerSource(model)
+                # Create a Photovoltaic DiTTo object
+                api_PV = Photovoltaic(model)
 
                 # Set the PV name
                 api_PV.name = GeneratorSectionID[i].lower().replace(" ", "_")

--- a/ditto/writers/ephasor/write.py
+++ b/ditto/writers/ephasor/write.py
@@ -19,6 +19,7 @@ from ditto.models.wire import Wire
 from ditto.models.capacitor import Capacitor
 from ditto.models.powertransformer import PowerTransformer
 from ditto.models.power_source import PowerSource
+from ditto.models.photovoltaic import Photovoltaic
 from ditto.models.winding import Winding
 
 from ditto.writers.abstract_writer import AbstractWriter
@@ -1212,6 +1213,7 @@ class Writer(AbstractWriter):
         ]
         self._regulators = [i for i in self.m.models if isinstance(i, Regulator)]
         self._powersources = [i for i in self.m.models if isinstance(i, PowerSource)]
+        self._photovoltaics = [i for i in self.m.models if isinstance(i, Photovoltaic)]
 
         df7 = self.source()
         df1 = self.line()


### PR DESCRIPTION
Should address point 2 raised in #166 
I'm unsure for the ```Ephasor``` writer. I don't think it supports PV systems yet. The PowerSource objects seem to be sources, not PVs. Coud you double check @tarekelgindy?

Needs #166 to be merged first!