### PR TITLE
Add is sectionalizer to wires

### DIFF
--- a/ditto/models/line.py
+++ b/ditto/models/line.py
@@ -127,7 +127,7 @@ class Line(DiTToHasTraits):
     # Modification: Nicolas (June 2018)
     is_network_protector = Int(
         help="""This flag indicates whether or not the line is also a network protector.""",
-        default_value=0,
+        default_value=None,
     )
 
     def build(

--- a/ditto/models/wire.py
+++ b/ditto/models/wire.py
@@ -93,6 +93,12 @@ class Wire(DiTToHasTraits):
         default_value=0,
     )
 
+    # Modification: Nicolas (August 2018)
+    is_sectionalizer = Int(
+        help="""This flag indicates whether or not this wire is also a sectionalizer.""",
+        default_value=None,
+    )
+
     def build(self, model):
         self._model = model
         pass

--- a/ditto/models/wire.py
+++ b/ditto/models/wire.py
@@ -90,7 +90,7 @@ class Wire(DiTToHasTraits):
     # Modification: Nicolas (June 2018)
     is_network_protector = Int(
         help="""This flag indicates whether or not this wire is also a network protector.""",
-        default_value=0,
+        default_value=None,
     )
 
     # Modification: Nicolas (August 2018)


### PR DESCRIPTION
It looks like the attribute ```is_sectionalizer``` was added to ```Line``` objects but not to ```Wire``` objects in the same way as the other flags like ```is_switch``` for example.

Also, the default value of ```is_network_protector``` was set to 0 while all other flags have a default set to ```None```. Changed that for consistency.