### PR TITLE
Add per unit to source

### DIFF
--- a/ditto/models/power_source.py
+++ b/ditto/models/power_source.py
@@ -23,6 +23,10 @@ class PowerSource(DiTToHasTraits):
         help="""This parameter defines the base voltage at the power source.""",
         default_value=None,
     )
+    per_unit = Float(
+        help="""This parameter defines the per unit voltage at the source.""",
+        default_value=1.0,
+    )
     phases = List(
         Instance(Unicode),
         help="""This parameter is a list of all the phases at the power source.""",

--- a/ditto/readers/opendss/read.py
+++ b/ditto/readers/opendss/read.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def timeit(method):
+
     def timed(*args, **kw):
         ts = time.time()
         result = method(*args, **kw)
@@ -359,6 +360,12 @@ class Reader(AbstractReader):
                 api_power_source.nominal_voltage = (
                     float(source_data["basekv"]) * 10 ** 3
                 )  # DiTTo in volts
+            except:
+                pass
+
+            # Set the per unit value of the source
+            try:
+                api_power_source.per_unit = float(source_data["pu"])
             except:
                 pass
 

--- a/ditto/readers/synergi/read.py
+++ b/ditto/readers/synergi/read.py
@@ -507,13 +507,12 @@ class Reader(AbstractReader):
             api_source.name = obj.lower().replace(" ", "_") + "_src"
 
             # Set the nominal voltage
-            # TODO: Not sure what to use here...
-            # Could be :
-            # api_source.nominal_voltage = NominalKvll_src[i] * 10**3 #DiTTo in volts
-            # or:
-            api_source.nominal_voltage = BusVoltageLevel[
-                i
-            ]  # This value should already be in volts
+            api_source.nominal_voltage = NominalKvll_src[i] * 10 ** 3  # DiTTo in volts
+
+            # Set the per unit
+            api_source.per_unit = (
+                BusVoltageLevel[i] / 120.0
+            )  # This value should already be in volts
 
             # Set the phases
             # TODO: Change this. I couln't find where this is defined

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -2838,7 +2838,9 @@ class Writer(AbstractWriter):
                         and obj.connecting_element is not None
                     ):
                         fp.write(
-                            "bus1={name} pu=1.0".format(name=obj.connecting_element)
+                            "bus1={name} pu={pu}".format(
+                                name=obj.connecting_element, pu=obj.per_unit
+                            )
                         )
                     else:
                         logger.warning(
@@ -2846,7 +2848,11 @@ class Writer(AbstractWriter):
                                 cleaned_name
                             )
                         )
-                        fp.write("bus1={name} pu=1.0".format(name=cleaned_name))
+                        fp.write(
+                            "bus1={name} pu={pu}".format(
+                                name=cleaned_name, pu=obj.per_unit
+                            )
+                        )
 
                     if (
                         hasattr(obj, "nominal_voltage")


### PR DESCRIPTION
- Add ```per-unit``` attribute to ```PowerSource``` object
- Update the ```OpenDSS``` reader and writer, as well as the ```Synergi``` reader to use this attribute.

*NOTE:* I'm still unsure whether we need to update the ```CYME``` parsers to use this. The SOURCE et SOURCE EQUIVALENT objects have only the nominal voltage specified. 
I've set the default value to be ```1.00p.u``` which used to be hardcoded in the ```OpenDSS``` writer anyway, so the behavior shouldn't change here (for smart-ds, the value will be parsed in but nothing will be done with it).

Also, no clue for the ```Gridlab-D``` reader or the ```Ephasor``` writer....