### PR TITLE
Opendss reader geometries bugfix

### DIFF
--- a/ditto/readers/opendss/read.py
+++ b/ditto/readers/opendss/read.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 
 
 def timeit(method):
+
     def timed(*args, **kw):
         ts = time.time()
         result = method(*args, **kw)
@@ -1000,7 +1001,7 @@ class Reader(AbstractReader):
 
             # Try to get the geometry code if it exists
             try:
-                line_geometry_code = data["geometry"]
+                line_geometry_code = data["geometry"].lower()
             except:
                 line_geometry_code = None
                 pass
@@ -1013,7 +1014,9 @@ class Reader(AbstractReader):
             if line_geometry_code is not None:
                 try:
                     line_geometries = dss.utils.class_to_dataframe("linegeometry")
-                    this_line_geometry = line_geometries[line_geometry_code]
+                    this_line_geometry = line_geometries[
+                        "linegeometry.{}".format(line_geometry_code)
+                    ]
                 except:
                     self.logger.warning(
                         "Could not get the geometry {line_geom} data of line {line_name}".format(
@@ -1095,7 +1098,9 @@ class Reader(AbstractReader):
 
                     # nameclass
                     try:
-                        wires[p].nameclass = this_line_geometry["wire"]
+                        wires[p].nameclass = this_line_geometry["wires"][0].split(" ")[
+                            p
+                        ]
                     except:
                         pass
 
@@ -1124,7 +1129,7 @@ class Reader(AbstractReader):
                     if line_geometry_unit is not None:
                         try:
                             wires[p].X = self.convert_to_meters(
-                                this_line_geometry["X"], line_geometry_unit
+                                float(this_line_geometry["x"]), line_geometry_unit
                             )
                         except:
                             pass
@@ -1134,14 +1139,14 @@ class Reader(AbstractReader):
                     if line_geometry_unit is not None:
                         try:
                             wires[p].Y = self.convert_to_meters(
-                                this_line_geometry["H"], line_geometry_unit
+                                float(this_line_geometry["h"]), line_geometry_unit
                             )
                         except:
                             pass
 
                     # Check if we have wireData that we can use
                     try:
-                        this_line_wireData_code = this_line_geometry["wire"]
+                        this_line_wireData_code = this_line_geometry["wire"].lower()
                     except:
                         this_line_wireData_code = None
 
@@ -1153,7 +1158,9 @@ class Reader(AbstractReader):
                     if this_line_wireData_code is not None:
                         try:
                             all_wire_data = dss.utils.class_to_dataframe("wiredata")
-                            this_line_wireData = all_wire_data[this_line_wireData_code]
+                            this_line_wireData = all_wire_data[
+                                "wiredata.{}".format(this_line_wireData_code)
+                            ]
                         except:
                             self.logger.warning(
                                 "Could not get the wireData {wiredata} of lineGeometry {line_geom}".format(
@@ -1170,7 +1177,7 @@ class Reader(AbstractReader):
 
                         # Get the unit for the radius distance
                         try:
-                            wire_radius_unit = this_line_wireData["Radunits"]
+                            wire_radius_unit = this_line_wireData["radunits"]
                         # If not present, assume the same unit as the lineGeometry
                         except:
                             self.logger(
@@ -1195,7 +1202,7 @@ class Reader(AbstractReader):
                         if wire_radius_unit is not None:
                             try:
                                 wires[p].diameter = self.convert_to_meters(
-                                    this_line_wireData["Diam"], wire_radius_unit
+                                    float(this_line_wireData["diam"]), wire_radius_unit
                                 )
                             except:
                                 pass
@@ -1227,22 +1234,22 @@ class Reader(AbstractReader):
                         if wire_gmr_unit is not None:
                             try:
                                 wires[p].gmr = self.convert_to_meters(
-                                    this_line_wireData["GMRac"], wire_gmr_unit
+                                    float(this_line_wireData["GMRac"]), wire_gmr_unit
                                 )
                             except:
                                 pass
 
                         # ampacity
                         try:
-                            wires[p].ampacity = this_line_wireData["Normamps"]
+                            wires[p].ampacity = float(this_line_wireData["normamps"])
                         except:
                             pass
 
                         # ampacity emergency
                         try:
-                            wires[p].ampacity_emergency = this_line_wireData[
-                                "Emergamps"
-                            ]
+                            wires[p].ampacity_emergency = float(
+                                this_line_wireData["emergamps"]
+                            )
                         except:
                             pass
 
@@ -1255,7 +1262,7 @@ class Reader(AbstractReader):
                         if length is not None:
                             # Try to get the per unit resistance
                             try:
-                                Rac = this_line_wireData["Rac"]
+                                Rac = float(this_line_wireData["Rac"])
                             except:
                                 Rac = None
                                 pass

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ numpy_dependency = "numpy>=1.13.0"
 
 extras_requires = ["lxml", "pandas", "scipy", numpy_dependency, "XlsxWriter"]
 
-opendss_requires = ["OpenDSSDirect.py", "pandas", numpy_dependency]
+opendss_requires = ["OpenDSSDirect.py>=0.3.3", "pandas", numpy_dependency]
 dew_requires = [numpy_dependency, "xlrd"]
 gridlabd_requires = ["croniter", numpy_dependency]
 cyme_requires = [numpy_dependency]
@@ -49,6 +49,7 @@ synergi_requires = [
     numpy_dependency,
     "pandas_access",
 ]  # Need pandas_access to convert the MDB tables to Pandas DataFrame
+
 
 class PostDevelopCommand(develop):
 

--- a/tests/data/ditto-validation/opendss/linegeometries/Master.dss
+++ b/tests/data/ditto-validation/opendss/linegeometries/Master.dss
@@ -1,0 +1,21 @@
+Clear
+
+New Circuit.test_circuit
+
+New Wiredata.ACSR336 GMR=0.0255000 DIAM=0.7410000 RAC=0.3060000 NormAmps=530.0000 Runits=mi radunits=in gmrunits=ft
+New Wiredata.ACSR1/0 GMR=0.0044600 DIAM=0.3980000 RAC=1.120000 NormAmps=230.0000 Runits=mi radunits=in gmrunits=ft
+
+
+New Linegeometry.HC2_336_1neut_0Mess nconds=4 nphases=3
+~ cond=1 Wire=ACSR336 x=-1.2909 h=13.716 units=m
+~ cond=2 Wire=ACSR336 x=-0.1530096 h=4.1806368 units=ft
+~ cond=3 Wire=ACSR336 x=0.5737 h=13.716 units=m
+~ cond=4 Wire= ACSR1/0 x=0 h=14.648 ! units=m ! neutral
+
+New Line.Line1 Bus1=bus1.1.2.3 Bus2=bus2.1.2.3
+~ Geometry= HC2_336_1neut_0Mess
+~ Length=300 units=ft
+
+Set Voltagebases=[4.8,34.5,115.0]
+Calcvoltagebases
+Solve

--- a/tests/test_opendss_reader.py
+++ b/tests/test_opendss_reader.py
@@ -14,6 +14,7 @@ import six
 import tempfile
 import pytest
 import pytest as pt
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -57,5 +58,69 @@ def test_disabled_objects():
     assert "regulator_reg3" not in m.model_names
     assert "regulator_reg2" not in m.model_names
     assert "reg2" in m.model_names
-    assert "671692" in m.model_names #Switch 671692 should exists....
-    assert [wire.is_open for wire in m["671692"].wires] == [1,1,1,1] #...but it should be open on all phases
+    assert "671692" in m.model_names  # Switch 671692 should exists....
+    assert [wire.is_open for wire in m["671692"].wires] == [
+        1,
+        1,
+        1,
+    ]  # ...but it should be open on all phases
+
+
+def test_linegeometries_and_wiredata():
+    """
+        Test the reading of linegeometries and wiredata.
+    """
+    from ditto.readers.opendss.read import Reader
+    from ditto.store import Store
+    from ditto.writers.opendss.write import Writer
+
+    m = Store()
+    r = Reader(
+        master_file=os.path.join(
+            current_directory, "data/ditto-validation/opendss/linegeometries/Master.dss"
+        )
+    )
+    r.parse(m)
+    m.set_names()
+
+    # Number of wires
+    assert len(m["line1"].wires) == 4  # Line1 should have 4 wires
+
+    # Phases of the different wires
+    assert [w.phase for w in m["line1"].wires] == ["A", "B", "C", "N"]
+
+    # Nameclass
+    assert [w.nameclass for w in m["line1"].wires] == ["ACSR336"] * 3 + ["ACSR1/0"]
+
+    # Positions of the wires
+    assert [w.X for w in m["line1"].wires] == [
+        -1.2909,
+        -0.1530096 * 0.3048,
+        0.5737,
+        0.0,
+    ]
+    assert [w.Y for w in m["line1"].wires] == [
+        13.716,
+        4.1806368 * 0.3048,
+        13.716,
+        14.648,
+    ]
+
+    # GMR
+    assert [w.gmr for w in m["line1"].wires] == [0.0255 * 0.3048] * 3 + [
+        0.00446 * 0.3048
+    ]
+
+    # Diameter
+    assert [w.diameter for w in m["line1"].wires] == [0.741 * 0.0254] * 3 + [
+        0.398 * 0.0254
+    ]
+
+    # Resistance
+    # TODO: Change this once the resistance of a Wire object will no longer be the total
+    # resistance, but the per meter resistance...
+    #
+    assert np.allclose(
+        [w.resistance for w in m["line1"].wires],
+        [0.306 * 0.000621371 * 300 * 0.3048] * 3 + [1.12 * 0.000621371 * 300 * 0.3048],
+    )


### PR DESCRIPTION
Addresses #164
```LineGeometries``` and ```WireData``` were not parsed before by the ```OpenDSS``` reader for multiple reasons (bugs in the reader code (which was never tested for this capability...), and bugs in ```OpenDSSdirect.py``` when trying to access these objects).

This PR should fix this. I added ```OpenDSSdirect.py>=0.3.3``` in the dependencies since the latest version is now required to pass the tests.