### PR TITLE
Export underground lines opendss

### DIFF
--- a/ditto/models/wire.py
+++ b/ditto/models/wire.py
@@ -21,8 +21,16 @@ class Wire(DiTToHasTraits):
         help="""The vertical placement above (or below) ground of the wire on a cross section of the line w.r.t. some point of reference (typically one wire on the configuration)""",
         default_value=None,
     )
-    diameter = Float(help="""The diameter of the conductor""", default_value=None)
-    gmr = Float(help="""The geometric mean radius of the wire""", default_value=None)
+    diameter = Float(
+        help="""The diameter of the conductor.
+        If the wire is a concentric neutral cable, this is the diameter of the phase conductor.""",
+        default_value=None,
+    )
+    gmr = Float(
+        help="""The geometric mean radius of the wire.
+        If the wire is a concentric neutral cable, this is the GMR of the phase conductor.""",
+        default_value=None,
+    )
     ampacity = Float(
         help="""The ampacity rating for the wire under nomal conditions""",
         default_value=None,
@@ -31,7 +39,11 @@ class Wire(DiTToHasTraits):
         help="""The ampacity rating for the wire under emergency conditions""",
         default_value=None,
     )
-    resistance = Float(help="""The total resistance of the wire""", default_value=None)
+    resistance = Float(
+        help="""The total resistance of the wire.
+        If the wire is a concentric neutral cable, this is the per-unit resistance of the phase conductor""",
+        default_value=None,
+    )
     insulation_thickness = Float(
         help="""Thickness of the insulation around the secondary live conductors""",
         default=None,
@@ -54,17 +66,32 @@ class Wire(DiTToHasTraits):
         help="""The maximum current that can pass through the wire before the equipment disconnects.""",
         default_value=None,
     )
+
+    # Concentric Neutral Specific
+    # This section should be used to model the Wire object as a concentric neutral cable
+    # If the wire is a basic bare conductor, leave undefined.
+    #
     concentric_neutral_gmr = Float(
-        help="""The geometric mean radius of the neutral for a concentric wire""",
+        help="""The geometric mean radius of the neutral strand for a concentric neutral cable.""",
         default_value=None,
     )
     concentric_neutral_resistance = Float(
-        help="""The total resistance of the neutral for a concentric wire""",
+        help="""The per-unit length resistance of the neutral strand for a concentric neutral cable.""",
         default_value=None,
     )
     concentric_neutral_diameter = Float(
-        help="""The diameter of the neutral for a concentric wire""", default_value=None
+        help="""The diameter of the neutral strand of the concentric neutral cable.""",
+        default_value=None,
     )
+    concentric_neutral_outside_diameter = Float(
+        help="""The outside diameter of the concentric neutral cable.""",
+        default_value=None,
+    )
+    concentric_neutral_nstrand = Int(
+        help="""The number of strands for the concentric neutral cable.""",
+        default_value=None,
+    )
+    ###############################################################
 
     # Modification: Nicolas Gensollen (December 2017)
     # Drop flag is used if we created objects in the reader that we do not want to output.

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -2143,19 +2143,56 @@ class Writer(AbstractWriter):
         for i in model.models:
             if isinstance(i, Line):
                 use_linecodes = False
-                for wire in i.wires:
-                    # If we are missing the position of at least one wire, default to linecodes
-                    if wire.X is None or wire.Y is None:
-                        use_linecodes = True
-                    # If we are missing the GMR of at least one wire, default to linecodes
-                    if wire.gmr is None:
-                        use_linecodes = True
-                    # If we are missing the diameter of at least one wire, default to linecodes
-                    if wire.diameter is None:
-                        use_linecodes = True
-                    # If we are missing the ampacity of at least one wire, default to linecodes
-                    if wire.ampacity is None:
-                        use_linecodes = True
+
+                # Find out if we have all the information we need to export
+                # the line using geometries. If we miss something, use LineCodes.
+                #
+                # For overhead (and undefined lines...)
+                if i.line_type != "underground":
+                    for wire in i.wires:
+                        # If we are missing the position of at least one wire, default to linecodes
+                        if wire.X is None or wire.Y is None:
+                            use_linecodes = True
+                        # If we are missing the GMR of at least one wire, default to linecodes
+                        if wire.gmr is None:
+                            use_linecodes = True
+                        # If we are missing the diameter of at least one wire, default to linecodes
+                        if wire.diameter is None:
+                            use_linecodes = True
+                        # If we are missing the ampacity of at least one wire, default to linecodes
+                        if wire.ampacity is None:
+                            use_linecodes = True
+                # For underground lines, we need a lot of data...
+                else:
+                    for wire in i.wires:
+                        # If we are missing the position of at least one wire, default to linecodes
+                        if wire.X is None or wire.Y is None:
+                            use_linecodes = True
+                        # If we are missing the GMR of at least one phase conductor, default to linecodes
+                        if wire.gmr is None:
+                            use_linecodes = True
+                        # If we are missing the diameter of at least one phase conductor, default to linecodes
+                        if wire.diameter is None:
+                            use_linecodes = True
+                        # If we are missing the ampacity of at least one wire, default to linecodes
+                        if wire.ampacity is None:
+                            use_linecodes = True
+                        # If we are missing the neutral strand GMR for at least one cable, default to linecodes
+                        if wire.concentric_neutral_gmr is None:
+                            use_linecodes = True
+                        # If we are missing the neutral strand resistance for at least one cable, default to linecodes
+                        if wire.concentric_neutral_resistance is None:
+                            use_linecodes = True
+                        # If we are missing the neutral strand diameter for at least one cable, default to linecodes
+                        if wire.concentric_neutral_diameter is None:
+                            use_linecodes = True
+                        # If we are missing the outside diameter for at least one cable, default to linecodes
+                        if wire.concentric_neutral_outside_diameter is None:
+                            use_linecodes = True
+                        # If we are missing the number of neutral strands for at least one cable, default to linecodes
+                        if wire.concentric_neutral_nstrand is None:
+                            use_linecodes = True
+
                 if use_linecodes:
                     lines_to_linecodify.append(i)
                 else:

--- a/tests/test_opendss_writer.py
+++ b/tests/test_opendss_writer.py
@@ -44,6 +44,50 @@ def test_parse_wire():
     assert parsed_wire["Rac"] == 5
 
 
+def test_parse_concentric_neutral_cable():
+    """
+    Tests the parsing of concentric neutral cables.
+
+    The example used is:
+
+    New CNDATA.250_1/3 k=13 DiaStrand=0.064 Rstrand=2.816666667 epsR=2.3
+    ~ InsLayer=0.220 DiaIns=1.06 DiaCable=1.16 Rac=0.076705 GMRac=0.20568 diam=0.573
+    ~ Runits=kft Radunits=in GMRunits=in
+    """
+    from ditto.store import Store
+    from ditto.models.wire import Wire
+    from ditto.writers.opendss.write import Writer
+
+    m = Store()
+    wire = Wire(
+        m,
+        phase="A",
+        nameclass="250_1/3",
+        diameter=0.0145542,  # 0.573 inches in meters
+        gmr=0.005224272,  # 0.20568 inches in meters
+        ampacity=500,
+        emergency_ampacity=1000,
+        resistance=0.000251656824147,  # 0.076705 ohm/kft in ohm/meter
+        concentric_neutral_resistance=0.00924103237205,  # 2.816666667 ohm/kft in ohm/meter
+        concentric_neutral_diameter=0.0016256,  # 0.064 inches in meters
+        concentric_neutral_outside_diameter=0.029464,  # 1.16 inches in meters
+        concentric_neutral_nstrand=13,
+    )
+    output_path = tempfile.gettempdir()
+    w = Writer(output_path=output_path)
+    parsed_cable = w.parse_cable(wire)
+    assert parsed_cable["k"] == 13
+    assert parsed_cable["DiaStrand"] == 0.0016256
+    assert parsed_cable["Rstrand"] == 0.00924103237205
+    assert parsed_cable["Diam"] == 0.0145542
+    assert parsed_cable["DiaCable"] == 0.029464
+    assert parsed_cable["Rac"] == 0.000251656824147
+    assert parsed_cable["GMRac"] == 0.005224272
+    assert parsed_cable["Runits"] == "m"
+    assert parsed_cable["Radunits"] == "m"
+    assert parsed_cable["GMRunits"] == "m"
+
+
 def setup_line_test():
     """Setup a line with 4 wires."""
     from ditto.store import Store


### PR DESCRIPTION
- Rework the `Wire` API to better model Concentric Neutral Cables. The `Wire` class should now be able to store enough information to compute the impedance matrix of the line using Carson's equations for underground lines. 
- The `OpenDSS` writer export underground lines as `CNData` if they have enough information stored.
- Add a test for the `parse_cable` function in the `OpenDSS` writer.

I'm planning to update the `OpenDSS`, `Synergi` or `CYME` reader and test parsing underground lines this way.