### PR TITLE
Add simple Capacitor writing test

### DIFF
--- a/tests/writers/opendss/capacitors/test_capacitor_writing.py
+++ b/tests/writers/opendss/capacitors/test_capacitor_writing.py
@@ -1,0 +1,82 @@
+"""
+test_capacitor_writing.py
+----------------------------------
+
+Tests for writing Capacitor objects from DiTTo to OpenDSS.
+"""
+
+import os
+import math
+import pytest
+import tempfile
+import numpy as np
+
+from ditto.store import Store
+from ditto.writers.opendss.write import Writer
+from ditto.models.capacitor import Capacitor
+from ditto.models.phase_capacitor import PhaseCapacitor
+
+current_directory = os.path.realpath(os.path.dirname(__file__))
+
+
+def test_single_phase_capacitor_writing():
+    m = Store()
+
+    # Create a one phase, 100kVar capacitor on phase A
+    cap1 = Capacitor(m)
+    cap1.name = "cap1"
+    cap1.nominal_voltage = 4.16 * 10 ** 3
+    cap1.connecting_element = "bus23"
+    cap1_A = PhaseCapacitor(m)
+    cap1_A.phase = "A"
+    cap1_A.var = 100 * 10 ** 3
+    cap1.phase_capacitors.append(cap1_A)
+
+    output_path = tempfile.gettempdir()
+    w = Writer(output_path=output_path)
+    w.write(m)
+
+    # Check that the OpenDSS writer created a Master file
+    assert os.path.exists(os.path.join(output_path, "Master.dss"))
+
+    # Check that the OpenDSS writer created a Capacitors.dss file
+    assert os.path.exists(os.path.join(output_path, "Capacitors.dss"))
+
+    with open(os.path.join(output_path, "Capacitors.dss"), "r") as fp:
+        lines = fp.readlines()
+
+    assert (
+        len(lines) == 2
+    )  # There is one line with the capacitor string and one empty line
+    assert lines[0] == "New Capacitor.cap1 Bus1=bus23.1 phases=1 Kv=4.16 Kvar=100.0\n"
+
+
+def test_three_phase_capacitor_writing():
+    m = Store()
+
+    # Create a one phase, 100kVar capacitor on phase A
+    cap1 = Capacitor(m)
+    cap1.connecting_element = "bus66"
+    cap1.nominal_voltage = 4.16 * 10 ** 3
+    cap1.name = "cap1"
+
+    for phase in ["A", "B", "C"]:
+        cap1.phase_capacitors.append(PhaseCapacitor(m, phase=phase, var=300 * 10 ** 3))
+
+    output_path = tempfile.gettempdir()
+    w = Writer(output_path=output_path)
+    w.write(m)
+
+    # Check that the OpenDSS writer created a Master file
+    assert os.path.exists(os.path.join(output_path, "Master.dss"))
+
+    # Check that the OpenDSS writer created a Capacitors.dss file
+    assert os.path.exists(os.path.join(output_path, "Capacitors.dss"))
+
+    with open(os.path.join(output_path, "Capacitors.dss"), "r") as fp:
+        lines = fp.readlines()
+
+    assert (
+        len(lines) == 2
+    )  # There is one line with the capacitor string and one empty line
+    assert lines[0] == "New Capacitor.cap1 Bus1=bus66 phases=3 Kv=4.16 Kvar=900.0\n"

--- a/tests/writers/opendss/capacitors/test_capacitor_writing.py
+++ b/tests/writers/opendss/capacitors/test_capacitor_writing.py
@@ -54,7 +54,7 @@ def test_single_phase_capacitor_writing():
 def test_three_phase_capacitor_writing():
     m = Store()
 
-    # Create a one phase, 100kVar capacitor on phase A
+    # Create a three phase, 900kVar capacitor
     cap1 = Capacitor(m)
     cap1.connecting_element = "bus66"
     cap1.nominal_voltage = 4.16 * 10 ** 3


### PR DESCRIPTION
Same as #198 but for the OpenDSS writer. The testing style is a little different from what we are doing for readers but this seems to be the obvious way of testing the writers.

I'm open to suggestions to improve this if needed.