### PR TITLE
Remove eval json reader

### DIFF
--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -7,6 +7,7 @@ import json_tricks
 
 # TODO: remove numpy dependency here
 import numpy
+from six import text_type
 
 from ditto.readers.abstract_reader import AbstractReader
 from ditto.store import Store
@@ -52,7 +53,7 @@ class_mapping = {
     "float": float,
     "str": str,
     "bool": bool,
-    "unicode": Unicode,
+    "unicode": text_type,
     "numpy.float64": numpy.float64,
 }
 

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -52,7 +52,7 @@ class_mapping = {
     "float": float,
     "str": str,
     "bool": bool,
-    "unicode": unicode,
+    "unicode": Unicode,
     "numpy.float64": numpy.float64,
 }
 

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -63,35 +63,35 @@ class Reader(AbstractReader):
     The reader expects the following format:
 
         - objects are stored in a list [object_1,object_2,...,object_N]
-        - Each object is a dictionary object_1={'klass':'PowerTransformer',
-                                                'is_substationr':{'klass':'int',
+        - Each object is a dictionary object_1={'class':'PowerTransformer',
+                                                'is_substationr':{'class':'int',
                                                                   'value':'1'
                                                                  },
                                                 (...)
                                                 }
-        - The special key 'klass' indicates the type of the object considered.
-        - klass can be:
+        - The special key 'class' indicates the type of the object considered.
+        - class can be:
                 - a DiTTo object type like 'PowerTransformer' or 'Winding'
                 - a "standard" type like 'int', 'float', or 'str'
                 - a list ('list')
-                - a complex number: 1+2j will be {'klass':'complex', 'value':[1,2]}
+                - a complex number: 1+2j will be {'class':'complex', 'value':[1,2]}
 
     .. note:: For nested objects, this format can become a bit complex. See example below
 
     **Example:**
 
-    object_1={'klass':'PowerTransformer',
-              'is_substation':{'klass':'int',
+    object_1={'class':'PowerTransformer',
+              'is_substation':{'class':'int',
                                'value':'1'
                              },
-              'windings':{'klass':'list',
-                          'value':[{'klass':'Winding',
-                                    'rated_power':{'klass':'float',
+              'windings':{'class':'list',
+                          'value':[{'class':'Winding',
+                                    'rated_power':{'class':'float',
                                                    'value':'1000'
                                                    }
-                                    'phase_windings':{'klass':'list',
-                                                      'value':[{'klass':'PhaseWinding',
-                                                                'phase':{'klass':'Unicode',
+                                    'phase_windings':{'class':'list',
+                                                      'value':[{'class':'PhaseWinding',
+                                                                'phase':{'class':'Unicode',
                                                                          'value':'C'
                                                                          },
                                                                 (...)
@@ -125,7 +125,7 @@ class Reader(AbstractReader):
         with open(self.input_file, "r") as f:
             input_data = json.load(f)
 
-        ditto_klasses = [
+        ditto_classes = [
             "PowerSource",
             "Photovoltaic",
             "Node",
@@ -150,13 +150,13 @@ class Reader(AbstractReader):
         for _object in input_data:
 
             # Get the class of the element
-            _klass = _object["klass"]
+            _class = _object["class"]
 
             # If it is a second level or third level class, ignore the object
             # These objects will be created when handling the first level object
             # Ex: When creating a PowerTransformer, corresponding Windings and
             # PhaseWindings will be created
-            if _klass in [
+            if _class in [
                 "Winding",
                 "PhaseWinding",
                 "Wire",
@@ -166,24 +166,24 @@ class Reader(AbstractReader):
             ]:
                 continue
 
-            # Use the klass to instantiate the proper DiTTo object
+            # Use the class to instantiate the proper DiTTo object
             # Ex: PowerTransformer
 
-            if _object["klass"] in class_mapping:
-                api_object = class_mapping[_object["klass"]](self.model)
+            if _object["class"] in class_mapping:
+                api_object = class_mapping[_object["class"]](self.model)
             else:
                 raise ValueError(
-                    "Class {cl} is not supported by DiTTo.".format(cl=_object["klass"])
+                    "Class {cl} is not supported by DiTTo.".format(cl=_object["class"])
                 )
 
             # Loop over the object properties.
             # Ex: name, postion...
             for object_property, property_value in _object.items():
 
-                if object_property != "klass":
+                if object_property != "class":
 
                     # Get the type of the property
-                    property_type = property_value["klass"]
+                    property_type = property_value["class"]
 
                     # Depending on this type, there are a few different scenarios...
                     # First, if it is a list...
@@ -194,17 +194,17 @@ class Reader(AbstractReader):
                         list_first_level = []
 
                         # Loop over the element in the list
-                        # Ex: element will be a dict {'klass':Winding, 'rated_power':{'klass':'float','value':10},...}
+                        # Ex: element will be a dict {'class':Winding, 'rated_power':{'class':'float','value':10},...}
                         for element in property_value["value"]:
 
                             # Get the type of each element
                             # Ex: Winding
-                            element_type = element["klass"]
+                            element_type = element["class"]
 
                             # Again, there are multiple possibilities
                             # First, it could be a DiTTo object.
                             # Ex: Winding
-                            if element_type in ditto_klasses:
+                            if element_type in ditto_classes:
 
                                 # Instanciate the proper DiTTo object
                                 # Ex: Winding
@@ -216,11 +216,11 @@ class Reader(AbstractReader):
                                 # Ex: rated_power...
                                 for element_property, element_value in element.items():
 
-                                    if element_property != "klass":
+                                    if element_property != "class":
 
                                         # Get the type of the property
                                         # Ex: float
-                                        nested_element_type = element_value["klass"]
+                                        nested_element_type = element_value["class"]
 
                                         # If it is a list...
                                         if nested_element_type == "list":
@@ -233,11 +233,11 @@ class Reader(AbstractReader):
 
                                                 # Get the class
                                                 element_deep_class = element_deep[
-                                                    "klass"
+                                                    "class"
                                                 ]
 
                                                 # If it is a DiTTo object
-                                                if element_deep_class in ditto_klasses:
+                                                if element_deep_class in ditto_classes:
 
                                                     # Create the proper object
                                                     api_object_two_level_deep = class_mapping[
@@ -254,13 +254,13 @@ class Reader(AbstractReader):
 
                                                         if (
                                                             nested_object_property
-                                                            != "klass"
+                                                            != "class"
                                                         ):
 
                                                             # At this point, it should be either a complex...
                                                             if (
                                                                 nested_object_property_value[
-                                                                    "klass"
+                                                                    "class"
                                                                 ]
                                                                 == "complex"
                                                             ):
@@ -285,7 +285,7 @@ class Reader(AbstractReader):
                                                             # ...or a standard type
                                                             elif (
                                                                 nested_object_property_value[
-                                                                    "klass"
+                                                                    "class"
                                                                 ]
                                                                 != "NoneType"
                                                             ):
@@ -295,7 +295,7 @@ class Reader(AbstractReader):
                                                                     nested_object_property,
                                                                     class_mapping[
                                                                         nested_object_property_value[
-                                                                            "klass"
+                                                                            "class"
                                                                         ]
                                                                     ](
                                                                         nested_object_property_value[
@@ -371,7 +371,7 @@ class Reader(AbstractReader):
                                 for element_deep in element["value"]:
 
                                     # They could be complex numbers
-                                    if element_deep["klass"] == "complex":
+                                    if element_deep["class"] == "complex":
 
                                         inner_list.append(
                                             complex(
@@ -381,10 +381,10 @@ class Reader(AbstractReader):
                                         )
 
                                     # Or standard numbers (int or float)
-                                    elif element_deep["klass"] != "NoneType":
+                                    elif element_deep["class"] != "NoneType":
 
                                         inner_list.append(
-                                            class_mapping[element_deep["klass"]](
+                                            class_mapping[element_deep["class"]](
                                                 element_deep["value"]
                                             )
                                         )

--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import, division, print_function
 from builtins import super, range, zip, round, map
 
-import json
+import json_tricks
 
 # TODO: remove numpy dependency here
 import numpy
@@ -123,7 +123,7 @@ class Reader(AbstractReader):
         """Parse a JSON file to a DiTTo model."""
         # Open the input file and get the data
         with open(self.input_file, "r") as f:
-            input_data = json.load(f)
+            input_data = json_tricks.load(f)
 
         ditto_classes = [
             "PowerSource",

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function
 from builtins import super, range, zip, round, map
 
 import os
-import json
 import json_tricks
 
 from ditto.writers.abstract_writer import AbstractWriter
@@ -229,7 +228,4 @@ class Writer(AbstractWriter):
                 }
 
         with open(os.path.join(self.output_path, self.filename), "w") as f:
-            try:
-                f.write(json.dumps(_model))
-            except:
-                f.write(json_tricks.dumps(_model, allow_nan=True))
+            f.write(json_tricks.dumps(_model, allow_nan=True))

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -24,35 +24,35 @@ class Writer(AbstractWriter):
     The writer produce a file with the following format:
 
         - objects are stored in a list [object_1,object_2,...,object_N]
-        - Each object is a dictionary object_1={'klass':'PowerTransformer',
-                                                'is_substationr':{'klass':'int',
+        - Each object is a dictionary object_1={'class':'PowerTransformer',
+                                                'is_substationr':{'class':'int',
                                                                   'value':'1'
                                                                  },
                                                 (...)
                                                 }
-        - The special key 'klass' indicates the type of the object considered.
-        - klass can be:
+        - The special key 'class' indicates the type of the object considered.
+        - class can be:
                 - a DiTTo object type like 'PowerTransformer' or 'Winding'
                 - a "standard" type like 'int', 'float', or 'str'
                 - a list ('list')
-                - a complex number: 1+2j will be {'klass':'complex', 'value':[1,2]}
+                - a complex number: 1+2j will be {'class':'complex', 'value':[1,2]}
 
     .. note:: For nested objects, this format can become a bit complex. See example below
 
     **Example:**
 
-    object_1={'klass':'PowerTransformer',
-              'is_substation':{'klass':'int',
+    object_1={'class':'PowerTransformer',
+              'is_substation':{'class':'int',
                                'value':'1'
                              },
-              'windings':{'klass':'list',
-                          'value':[{'klass':'Winding',
-                                    'rated_power':{'klass':'float',
+              'windings':{'class':'list',
+                          'value':[{'class':'Winding',
+                                    'rated_power':{'class':'float',
                                                    'value':'1000'
                                                    }
-                                    'phase_windings':{'klass':'list',
-                                                      'value':[{'klass':'PhaseWinding',
-                                                                'phase':{'klass':'Unicode',
+                                    'phase_windings':{'class':'list',
+                                                      'value':[{'class':'PhaseWinding',
+                                                                'phase':{'class':'Unicode',
                                                                          'value':'C'
                                                                          },
                                                                 (...)
@@ -93,8 +93,8 @@ class Writer(AbstractWriter):
 
         _model = []
         for obj in model.models:
-            _klass = type(obj).__name__
-            if _klass in [
+            _class = type(obj).__name__
+            if _class in [
                 Winding,
                 PhaseWinding,
                 Wire,
@@ -104,113 +104,113 @@ class Writer(AbstractWriter):
             ]:
                 continue
             _model.append({})
-            _model[-1]["klass"] = _klass
+            _model[-1]["class"] = _class
 
             try:
-                _model[-1]["name"] = {"klass": "str", "value": obj.name}
+                _model[-1]["name"] = {"class": "str", "value": obj.name}
             except:
-                _model[-1]["name"] = {"klass": "str", "value": None}
+                _model[-1]["name"] = {"class": "str", "value": None}
                 pass
 
             for key, value in obj._trait_values.items():
                 if key in ["capacitance_matrix", "impedance_matrix", "reactances"]:
-                    _model[-1][key] = {"klass": "list", "value": []}
+                    _model[-1][key] = {"class": "list", "value": []}
                     for v in value:
                         if isinstance(v, complex):
                             _model[-1][key]["value"].append(
-                                {"klass": "complex", "value": [v.real, v.imag]}
+                                {"class": "complex", "value": [v.real, v.imag]}
                             )
                         elif isinstance(v, list):
                             _model[-1][key]["value"].append(
-                                {"klass": "list", "value": []}
+                                {"class": "list", "value": []}
                             )
                             for vv in v:
                                 if isinstance(vv, complex):
                                     _model[-1][key]["value"][-1]["value"].append(
                                         {
-                                            "klass": "complex",
+                                            "class": "complex",
                                             "value": [vv.real, vv.imag],
                                         }
                                     )
                                 else:
                                     _model[-1][key]["value"][-1]["value"].append(
                                         {
-                                            "klass": str(type(vv)).split("'")[1],
+                                            "class": str(type(vv)).split("'")[1],
                                             "value": vv,
                                         }
                                     )
                         else:
                             _model[-1][key]["value"].append(
-                                {"klass": str(type(v)).split("'")[1], "value": v}
+                                {"class": str(type(v)).split("'")[1], "value": v}
                             )
                     continue
                 if isinstance(value, list):
-                    _model[-1][key] = {"klass": "list", "value": []}
+                    _model[-1][key] = {"class": "list", "value": []}
                     for v in value:
 
                         if isinstance(v, complex):
                             _model[-1][key]["value"].append(
-                                {"klass": "complex", "value": [v.real, v.imag]}
+                                {"class": "complex", "value": [v.real, v.imag]}
                             )
 
                         elif isinstance(v, Position):
-                            _model[-1][key]["value"].append({"klass": "Position"})
+                            _model[-1][key]["value"].append({"class": "Position"})
                             for kkk, vvv in v._trait_values.items():
                                 _model[-1][key]["value"][-1][kkk] = {
-                                    "klass": str(type(vvv)).split("'")[1],
+                                    "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
                         elif isinstance(v, Unicode):
                             _model[-1][key]["value"].append(
-                                {"klass": "Unicode", "value": v.default_value}
+                                {"class": "Unicode", "value": v.default_value}
                             )
 
                         elif isinstance(v, Wire):
-                            _model[-1][key]["value"].append({"klass": "Wire"})
+                            _model[-1][key]["value"].append({"class": "Wire"})
                             for kkk, vvv in v._trait_values.items():
                                 _model[-1][key]["value"][-1][kkk] = {
-                                    "klass": str(type(vvv)).split("'")[1],
+                                    "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
                         elif isinstance(v, PhaseCapacitor):
-                            _model[-1][key]["value"].append({"klass": "PhaseCapacitor"})
+                            _model[-1][key]["value"].append({"class": "PhaseCapacitor"})
                             for kkk, vvv in v._trait_values.items():
                                 _model[-1][key]["value"][-1][kkk] = {
-                                    "klass": str(type(vvv)).split("'")[1],
+                                    "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
                         elif isinstance(v, Winding):
-                            _model[-1][key]["value"].append({"klass": "Winding"})
+                            _model[-1][key]["value"].append({"class": "Winding"})
                             for kkk, vvv in v._trait_values.items():
                                 if kkk != "phase_windings":
                                     _model[-1][key]["value"][-1][kkk] = {
-                                        "klass": str(type(vvv)).split("'")[1],
+                                        "class": str(type(vvv)).split("'")[1],
                                         "value": vvv,
                                     }
                             _model[-1][key]["value"][-1]["phase_windings"] = {
-                                "klass": "list",
+                                "class": "list",
                                 "value": [],
                             }
                             for phw in v.phase_windings:
                                 _model[-1][key]["value"][-1]["phase_windings"][
                                     "value"
-                                ].append({"klass": "PhaseWinding"})
+                                ].append({"class": "PhaseWinding"})
                                 for kkkk, vvvv in phw._trait_values.items():
                                     _model[-1][key]["value"][-1]["phase_windings"][
                                         "value"
                                     ][-1][kkkk] = {
-                                        "klass": str(type(vvvv)).split("'")[1],
+                                        "class": str(type(vvvv)).split("'")[1],
                                         "value": vvvv,
                                     }
 
                         elif isinstance(v, PhaseLoad):
-                            _model[-1][key]["value"].append({"klass": "PhaseLoad"})
+                            _model[-1][key]["value"].append({"class": "PhaseLoad"})
                             for kkk, vvv in v._trait_values.items():
                                 _model[-1][key]["value"][-1][kkk] = {
-                                    "klass": str(type(vvv)).split("'")[1],
+                                    "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
@@ -218,13 +218,13 @@ class Writer(AbstractWriter):
 
                 if isinstance(value, complex):
                     _model[-1][key] = {
-                        "klass": "complex",
+                        "class": "complex",
                         "value": [value.real, value.imag],
                     }
                     continue
 
                 _model[-1][key] = {
-                    "klass": str(type(value)).split("'")[1],
+                    "class": str(type(value)).split("'")[1],
                     "value": value,
                 }
 


### PR DESCRIPTION
This PR does:
- Remove use of `eval` in the JSON reader (see #141)
- Remove use of `json` and only use `json_tricks`
- Replace all `klass` by `class`
This is also related to #48 

I'm still getting a test fail but I'm not sure I understand why. I basically map `Unicode` to the DiTTo base `Unicode` class and `unicode` to the same thing since mapping it to the Python `unicode` is raising an error in Python 3...

So, if I do:
```python 
class_mapping["unicode"] = unicode
```
then tests pass for Python 2.7 but not for Python 3. And if I do
```python
from ditto.models.base import Unicode
class_mapping["unicode"] = Unicode
```
then the tests pass for Python 3 and fail for Python 2.7 with the following error:

```
TraitError: The 'name' trait of a PowerSource instance must be a unicode string, but a value of <ditto.models.base.Unicode object at 0x151e2a8410> <class 'ditto.models.base.Unicode'> was specified.
```

Which is surprising since `name` is defined as:

```python
name = Unicode(help="""Name of the power source object""")
```

Has anyone an idea on this???