### PR TITLE
Change json structure

### DIFF
--- a/ditto/readers/json/read.py
+++ b/ditto/readers/json/read.py
@@ -63,19 +63,26 @@ class Reader(AbstractReader):
 
     The reader expects the following format:
 
-        - objects are stored in a list [object_1,object_2,...,object_N]
-        - Each object is a dictionary object_1={'class':'PowerTransformer',
-                                                'is_substationr':{'class':'int',
-                                                                  'value':'1'
-                                                                 },
-                                                (...)
-                                                }
-        - The special key 'class' indicates the type of the object considered.
-        - class can be:
-                - a DiTTo object type like 'PowerTransformer' or 'Winding'
-                - a "standard" type like 'int', 'float', or 'str'
-                - a list ('list')
-                - a complex number: 1+2j will be {'class':'complex', 'value':[1,2]}
+    {"model": [object_1,object_2,...,object_N],
+     "metadata": {"time": time,
+                  ...
+                  }
+    }
+
+    The actual DiTTo model is stored in "model" as a list of objects.
+    Each object is a dictionary object_1={'class':'PowerTransformer',
+                                          'is_substationr':{'class':'int',
+                                                            'value':'1'
+                                                            },
+                                          (...)
+                                         }
+
+    The special key 'class' indicates the type of the object considered.
+    class can be:
+        - a DiTTo object type like 'PowerTransformer' or 'Winding'
+        - a "standard" type like 'int', 'float', or 'str'
+        - a list ('list')
+        - a complex number: 1+2j will be {'class':'complex', 'value':[1,2]}
 
     .. note:: For nested objects, this format can become a bit complex. See example below
 
@@ -147,8 +154,14 @@ class Reader(AbstractReader):
         # Create a new empty model
         self.model = Store()
 
+        if "model" not in input_data:
+            raise ValueError("No model found in the JSON file provided")
+
+        if not isinstance(input_data["model"], list):
+            raise TypeError("Model in JSON file should be a list of objects.")
+
         # Loop over the objects...
-        for _object in input_data:
+        for _object in input_data["model"]:
 
             # Get the class of the element
             _class = _object["class"]

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -256,4 +256,4 @@ class Writer(AbstractWriter):
                 }
 
         with open(os.path.join(self.output_path, self.filename), "w") as f:
-            f.write(json_tricks.dumps(json_dump["model"], allow_nan=True, indent=4))
+            f.write(json_tricks.dumps(json_dump, allow_nan=True, indent=4))

--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -5,6 +5,7 @@ from builtins import super, range, zip, round, map
 
 import os
 import json_tricks
+from datetime import datetime
 
 from ditto.writers.abstract_writer import AbstractWriter
 from ditto.models.position import Position
@@ -22,19 +23,25 @@ class Writer(AbstractWriter):
 
     The writer produce a file with the following format:
 
-        - objects are stored in a list [object_1,object_2,...,object_N]
-        - Each object is a dictionary object_1={'class':'PowerTransformer',
-                                                'is_substationr':{'class':'int',
-                                                                  'value':'1'
-                                                                 },
-                                                (...)
-                                                }
-        - The special key 'class' indicates the type of the object considered.
-        - class can be:
-                - a DiTTo object type like 'PowerTransformer' or 'Winding'
-                - a "standard" type like 'int', 'float', or 'str'
-                - a list ('list')
-                - a complex number: 1+2j will be {'class':'complex', 'value':[1,2]}
+    {"model": [object_1,object_2,...,object_N],
+     "metadata": {"time": time,
+                  ...
+                  }
+    }
+
+    The actual DiTTo model is stored in "model" as a list of objects.
+    Each object is a dictionary object_1={'class':'PowerTransformer',
+                                          'is_substationr':{'class':'int',
+                                                            'value':'1'
+                                                            },
+                                          (...)
+                                         }
+    The special key 'class' indicates the type of the object considered.
+    class can be:
+        - a DiTTo object type like 'PowerTransformer' or 'Winding'
+        - a "standard" type like 'int', 'float', or 'str'
+        - a list ('list')
+        - a complex number: 1+2j will be {'class':'complex', 'value':[1,2]}
 
     .. note:: For nested objects, this format can become a bit complex. See example below
 
@@ -90,7 +97,15 @@ class Writer(AbstractWriter):
         The output file is configured in the constructor.
         """
 
-        _model = []
+        # Initialize json_dump
+        json_dump = {"model": [], "metadata": {}}
+
+        # Set timestamp in metadata
+        json_dump["metadata"]["time"] = str(datetime.now())
+
+        # Set the size of the model in metadata
+        json_dump["metadata"]["model_size"] = len(model.models)
+
         for obj in model.models:
             _class = type(obj).__name__
             if _class in [
@@ -102,113 +117,126 @@ class Writer(AbstractWriter):
                 PhaseLoad,
             ]:
                 continue
-            _model.append({})
-            _model[-1]["class"] = _class
+            json_dump["model"].append({})
+            json_dump["model"][-1]["class"] = _class
 
             try:
-                _model[-1]["name"] = {"class": "str", "value": obj.name}
+                json_dump["model"][-1]["name"] = {"class": "str", "value": obj.name}
             except:
-                _model[-1]["name"] = {"class": "str", "value": None}
+                json_dump["model"][-1]["name"] = {"class": "str", "value": None}
                 pass
 
             for key, value in obj._trait_values.items():
                 if key in ["capacitance_matrix", "impedance_matrix", "reactances"]:
-                    _model[-1][key] = {"class": "list", "value": []}
+                    json_dump["model"][-1][key] = {"class": "list", "value": []}
                     for v in value:
                         if isinstance(v, complex):
-                            _model[-1][key]["value"].append(
+                            json_dump["model"][-1][key]["value"].append(
                                 {"class": "complex", "value": [v.real, v.imag]}
                             )
                         elif isinstance(v, list):
-                            _model[-1][key]["value"].append(
+                            json_dump["model"][-1][key]["value"].append(
                                 {"class": "list", "value": []}
                             )
                             for vv in v:
                                 if isinstance(vv, complex):
-                                    _model[-1][key]["value"][-1]["value"].append(
+                                    json_dump["model"][-1][key]["value"][-1][
+                                        "value"
+                                    ].append(
                                         {
                                             "class": "complex",
                                             "value": [vv.real, vv.imag],
                                         }
                                     )
                                 else:
-                                    _model[-1][key]["value"][-1]["value"].append(
+                                    json_dump["model"][-1][key]["value"][-1][
+                                        "value"
+                                    ].append(
                                         {
                                             "class": str(type(vv)).split("'")[1],
                                             "value": vv,
                                         }
                                     )
                         else:
-                            _model[-1][key]["value"].append(
+                            json_dump["model"][-1][key]["value"].append(
                                 {"class": str(type(v)).split("'")[1], "value": v}
                             )
                     continue
                 if isinstance(value, list):
-                    _model[-1][key] = {"class": "list", "value": []}
+                    json_dump["model"][-1][key] = {"class": "list", "value": []}
                     for v in value:
 
                         if isinstance(v, complex):
-                            _model[-1][key]["value"].append(
+                            json_dump["model"][-1][key]["value"].append(
                                 {"class": "complex", "value": [v.real, v.imag]}
                             )
 
                         elif isinstance(v, Position):
-                            _model[-1][key]["value"].append({"class": "Position"})
+                            json_dump["model"][-1][key]["value"].append(
+                                {"class": "Position"}
+                            )
                             for kkk, vvv in v._trait_values.items():
-                                _model[-1][key]["value"][-1][kkk] = {
+                                json_dump["model"][-1][key]["value"][-1][kkk] = {
                                     "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
                         elif isinstance(v, Unicode):
-                            _model[-1][key]["value"].append(
+                            json_dump["model"][-1][key]["value"].append(
                                 {"class": "Unicode", "value": v.default_value}
                             )
 
                         elif isinstance(v, Wire):
-                            _model[-1][key]["value"].append({"class": "Wire"})
+                            json_dump["model"][-1][key]["value"].append(
+                                {"class": "Wire"}
+                            )
                             for kkk, vvv in v._trait_values.items():
-                                _model[-1][key]["value"][-1][kkk] = {
+                                json_dump["model"][-1][key]["value"][-1][kkk] = {
                                     "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
                         elif isinstance(v, PhaseCapacitor):
-                            _model[-1][key]["value"].append({"class": "PhaseCapacitor"})
+                            json_dump["model"][-1][key]["value"].append(
+                                {"class": "PhaseCapacitor"}
+                            )
                             for kkk, vvv in v._trait_values.items():
-                                _model[-1][key]["value"][-1][kkk] = {
+                                json_dump["model"][-1][key]["value"][-1][kkk] = {
                                     "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
 
                         elif isinstance(v, Winding):
-                            _model[-1][key]["value"].append({"class": "Winding"})
+                            json_dump["model"][-1][key]["value"].append(
+                                {"class": "Winding"}
+                            )
                             for kkk, vvv in v._trait_values.items():
                                 if kkk != "phase_windings":
-                                    _model[-1][key]["value"][-1][kkk] = {
+                                    json_dump["model"][-1][key]["value"][-1][kkk] = {
                                         "class": str(type(vvv)).split("'")[1],
                                         "value": vvv,
                                     }
-                            _model[-1][key]["value"][-1]["phase_windings"] = {
-                                "class": "list",
-                                "value": [],
-                            }
+                            json_dump["model"][-1][key]["value"][-1][
+                                "phase_windings"
+                            ] = {"class": "list", "value": []}
                             for phw in v.phase_windings:
-                                _model[-1][key]["value"][-1]["phase_windings"][
-                                    "value"
-                                ].append({"class": "PhaseWinding"})
+                                json_dump["model"][-1][key]["value"][-1][
+                                    "phase_windings"
+                                ]["value"].append({"class": "PhaseWinding"})
                                 for kkkk, vvvv in phw._trait_values.items():
-                                    _model[-1][key]["value"][-1]["phase_windings"][
-                                        "value"
-                                    ][-1][kkkk] = {
+                                    json_dump["model"][-1][key]["value"][-1][
+                                        "phase_windings"
+                                    ]["value"][-1][kkkk] = {
                                         "class": str(type(vvvv)).split("'")[1],
                                         "value": vvvv,
                                     }
 
                         elif isinstance(v, PhaseLoad):
-                            _model[-1][key]["value"].append({"class": "PhaseLoad"})
+                            json_dump["model"][-1][key]["value"].append(
+                                {"class": "PhaseLoad"}
+                            )
                             for kkk, vvv in v._trait_values.items():
-                                _model[-1][key]["value"][-1][kkk] = {
+                                json_dump["model"][-1][key]["value"][-1][kkk] = {
                                     "class": str(type(vvv)).split("'")[1],
                                     "value": vvv,
                                 }
@@ -216,16 +244,16 @@ class Writer(AbstractWriter):
                     continue
 
                 if isinstance(value, complex):
-                    _model[-1][key] = {
+                    json_dump["model"][-1][key] = {
                         "class": "complex",
                         "value": [value.real, value.imag],
                     }
                     continue
 
-                _model[-1][key] = {
+                json_dump["model"][-1][key] = {
                     "class": str(type(value)).split("'")[1],
                     "value": value,
                 }
 
         with open(os.path.join(self.output_path, self.filename), "w") as f:
-            f.write(json_tricks.dumps(_model, allow_nan=True, indent=4))
+            f.write(json_tricks.dumps(json_dump["model"], allow_nan=True, indent=4))


### PR DESCRIPTION
Change the previous Json structure to be a dictionary instead of a list.
We now have the following structure:

```python
{"model": [object1, object2...],
 "metadata": {"time": 2018-10-24 ...,
              "size": 33,
             }
}
```
So far I'm only storing the time and number of objects (counted before writing) in the metadata, but we can add a lot more stuff like input format, inference of missing parameters, and so on...
