### PR TITLE
Sort when writing to JSON

### DIFF
--- a/ditto/writers/json/write.py
+++ b/ditto/writers/json/write.py
@@ -256,4 +256,6 @@ class Writer(AbstractWriter):
                 }
 
         with open(os.path.join(self.output_path, self.filename), "w") as f:
-            f.write(json_tricks.dumps(json_dump, allow_nan=True, indent=4))
+            f.write(
+                json_tricks.dumps(json_dump, allow_nan=True, sort_keys=True, indent=4)
+            )


### PR DESCRIPTION
Sort keys before writing to JSON. Might be good to merge this before #219 and update the JSON files in there.
We don't need to sort the dicts for the tests but it will be easier to compare the diffs between two of them if they get written in a deterministic way.

@tarekelgindy @kdheepak does this make sense?