### PR TITLE
Fix typo in documentation

### DIFF
--- a/ditto/models/winding.py
+++ b/ditto/models/winding.py
@@ -47,7 +47,7 @@ class Winding(DiTToHasTraits):
         default_value=None,
     )
     is_grounded = Bool(
-        help="""The boolean value to indicate whether tis winding is grounded or not""",
+        help="""The boolean value to indicate whether the winding is grounded or not""",
     )
 
     # Added by Nicolas (August 2017)


### PR DESCRIPTION
As much as I'd like for this is to be a valid contraction of "it is", I think documentation should be more formal.