### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@
 FROM python:3.6-slim
 
 # Install latest version of ditto
-RUN apt-get update; apt-get install -y git
-RUN git clone --depth 1 https://github.com/NREL/ditto.git
-WORKDIR ditto
+COPY ./ $HOME/ditto
+WORKDIR $HOME/ditto
 
 # Install ditto dependencies
 RUN python -m pip install --upgrade pip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build ditto
+# docker build . -t ditto
+
+# Run ditto
+# docker run --rm -ti ditto --help
+
+# https://hub.docker.com/_/python
+FROM python:3.6-slim-bullseye
+
+# Install latest version of ditto
+RUN apt-get update; apt-get install -y git
+RUN git clone --depth 1 https://github.com/NREL/ditto.git
+WORKDIR ditto
+
+# Install ditto dependencies
+RUN python -m pip install --upgrade pip && \
+pip install -e .[all] && \
+pip install pytest
+
+# Validate install
+RUN pytest -sv
+RUN ditto --help
+
+# By using an ENTRYPOINT, all of the arguments to docker
+# run following the image name are passed as arguments
+ENTRYPOINT [ "ditto" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # docker run --rm -ti ditto --help
 
 # https://hub.docker.com/_/python
-FROM python:3.6-slim-bullseye
+FROM python:3.6-slim
 
 # Install latest version of ditto
 RUN apt-get update; apt-get install -y git


### PR DESCRIPTION
This PR allows users to run the `ditto` with Python version 3.6 without requiring a local development environment to be setup.

1. Build the Docker container
```bash
docker build . -t ditto
```

2. Run `ditto`
```bash
docker run --rm -ti ditto --help
```

As a next step, it would be great to have official builds hosted on [https://hub.docker.com](https://hub.docker.com/).