### PR TITLE
improve cyme reader logging, power factor handling, doc strings

### DIFF
--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -5735,9 +5735,9 @@ class Reader(AbstractReader):
                         p, PF = float(settings["value1"]), float(settings["value2"])
                         if PF == 0:
                             q = 0
-                        elif 0 < PF <= 1:
+                        elif 0 < abs(PF) <= 1:
                             q = p * math.sqrt((1 - PF ** 2) / PF ** 2)
-                        elif 1 < PF <= 100:
+                        elif 1 < abs(PF) <= 100:
                             PF /= 100.0
                             q = p * math.sqrt((1 - PF ** 2) / PF ** 2)
                         else:

--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -5714,9 +5714,7 @@ class Reader(AbstractReader):
                     try:
                         p, q = float(settings["value1"]), float(settings["value2"])
                     except:
-                        logger.warning(
-                            "WARNING:: Skipping load on section {}".format(sectionID)
-                        )
+                        logger.warning(f"Problem with load on section {sectionID} with value_type=0 (P,Q). value1={settings['value1']}  value2={settings['value2']}")
                         continue
                 elif value_type == 1:  # KVA and PF are given
                     try:
@@ -5729,9 +5727,7 @@ class Reader(AbstractReader):
                         p = kva * PF
                         q = math.sqrt(kva ** 2 - p ** 2)
                     except:
-                        logger.warning(
-                            "WARNING:: Skipping load on section {}".format(sectionID)
-                        )
+                        logger.warning(f"Problem with load on section {sectionID} with value_type=1 (kVa, PF). value1={settings['value1']}  value2={settings['value2']}")
                         continue
                 elif value_type == 2:  # P and PF are given
 
@@ -5743,16 +5739,15 @@ class Reader(AbstractReader):
                             PF /= 100.0
                             q = p * math.sqrt((1 - PF ** 2) / PF ** 2)
                         else:
-                            logger.warning("problem with PF")
-                            logger.warning(PF)
+                            logger.warning(f"Problem with load on section {sectionID} with value_type=2 (P, PF). value1={settings['value1']}  value2={settings['value2']}")
                     except:
-                        logger.warning("Skipping load on section {}".format(sectionID))
+                        logger.warning(f"Problem with load on section {sectionID} with value_type=2 (P, PF). value1={settings['value1']}  value2={settings['value2']}")
                         continue
 
                 elif value_type == 3:  # AMP and PF are given
                     # TODO
                     logger.warning(
-                        "WARNING:: Skipping load on section {}".format(sectionID)
+                        "WARNING:: Skipping load on section {} because value_type=3 (AMP and PF)".format(sectionID)
                     )
                     continue
 

--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -758,7 +758,7 @@ class Reader(AbstractReader):
         """
         .. warning:: This is a helper function for the parsers. Do not use directly.
 
-        Takes as input the  object we want to parse (eg. "section" maps to "[SECTION]") 
+        Takes as input the object we want to parse (eg. "section" maps to "[SECTION]") 
         as well as the list of attributes we want to extract (eg. ["sectionid", "fromnodeid", "tonodeid", "phase"]).
         Also takes the default positions of the attributes (mapping), which is overwritten if "format" is found in the lines.
         The function returns a dictionary of dictionaries, where each sub-dictionary contains the values of the desired attributes of a CYME object.
@@ -807,7 +807,7 @@ class Reader(AbstractReader):
                             idx2 = temp[0]
                             mapping[attribute_list[idx2]] = idx
                 except:
-                    pass
+                    logger.warn(f"Unable to parse CYME line FORMAT for {obj} in {next_line}")
 
                 next_line = next(self.content)
 
@@ -860,10 +860,7 @@ class Reader(AbstractReader):
                         attribute_list = additional_attributes
                         additional_attributes = []
                     except:
-                        logger.warning(
-                            "Attempted to apply additional attributes but failed"
-                        )
-                        pass
+                        logger.warn(f"Unable to parse additional CYME line FORMAT for {obj} in {next_line}")
 
                 try:
                     next_line = next(self.content)

--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -5733,7 +5733,9 @@ class Reader(AbstractReader):
 
                     try:
                         p, PF = float(settings["value1"]), float(settings["value2"])
-                        if 0 <= PF <= 1:
+                        if PF == 0:
+                            q = 0
+                        elif 0 < PF <= 1:
                             q = p * math.sqrt((1 - PF ** 2) / PF ** 2)
                         elif 1 < PF <= 100:
                             PF /= 100.0

--- a/ditto/readers/cyme/read.py
+++ b/ditto/readers/cyme/read.py
@@ -3024,7 +3024,6 @@ class Reader(AbstractReader):
                     line_data = self.concentric_neutral_cable[settings["linecableid"]]
                     line_data["type"] = "balanced_line"
                 if settings["linecableid"] in self.cables:
-                    logger.debug("cables {}".format(sectionID))
                     line_data = self.cables[settings["linecableid"]]
                     line_data["type"] = "balanced_line"
 


### PR DESCRIPTION
## Bug fixes
- can now handle power factor <= 0

## Improvements
- removed some unnecessary logging
- improved debug messages
- `parser_helper` was taking in a list of object names but only parsing the first item in the list (by design), so I made that list argument a single argument
- added some typing to signatures and improved doc strings, added comments