### PR TITLE
Opendss writer: add unbalanced loads

### DIFF
--- a/ditto/models/winding.py
+++ b/ditto/models/winding.py
@@ -30,6 +30,9 @@ class Winding(DiTToHasTraits):
     nominal_voltage = Float(
         help="""The nominal voltage of the transformer winding""", default_value=None
     )
+    base_voltage = Float(
+        help="""The voltage basis for per unit calculations""", default_value=None
+    )
     voltage_limit = Float(
         help="""The maximum voltage allowed on the PT secondary.""", default_value=None
     )

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -138,6 +138,9 @@ class Writer(AbstractWriter):
     def write(self, model, **kwargs):
         """General writing function responsible for calling the sub-functions.
 
+        Note: .replace(".","_").replace(" ", "_") are used to fix node/bus names for OpenDSS, 
+            which uses dots for phase designation and spaces for paramater delimiters.
+
         :param model: DiTTo model
         :type model: DiTTo model
         :param verbose: Set verbose mode. Optional. Default=False
@@ -239,7 +242,7 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         if self.verbose:
-            logger.debug("Writting done.")
+            logger.debug("Writing done.")
 
         return 1
 
@@ -341,7 +344,7 @@ class Writer(AbstractWriter):
                         txt = feeder_text_map[substation_name + "_" + feeder_name]
 
                     txt += "{name} {X} {Y}\n".format(
-                        name=i.name.lower(), X=i.positions[0].long, Y=i.positions[0].lat
+                        name=i.name.lower().replace(".","_").replace(" ", "_"), X=i.positions[0].long, Y=i.positions[0].lat
                     )
                     feeder_text_map[substation_name + "_" + feeder_name] = txt
 
@@ -678,7 +681,7 @@ class Writer(AbstractWriter):
 
                                 if buses is not None:
                                     bus = buses[cnt]
-                                    txt += " bus={bus}".format(bus=str(bus))
+                                    txt += " bus={bus}".format(bus=str(bus).replace(".","_").replace(" ", "_"))
 
                                 if len(winding.phase_windings) != 3:
 
@@ -781,9 +784,9 @@ class Writer(AbstractWriter):
                             if buses is not None:
 
                                 if cnt == 0 or cnt == 1:
-                                    txt += " bus={b}".format(b=buses[cnt])
+                                    txt += " bus={b}".format(b=buses[cnt].replace(".","_").replace(" ", "_"))
                                 elif cnt == 2:
-                                    txt += " bus={b}".format(b=buses[cnt - 1])
+                                    txt += " bus={b}".format(b=buses[cnt - 1].replace(".","_").replace(" ", "_"))
 
                                 # These are the configurations for center tap transformers
                                 if cnt == 0:
@@ -1072,7 +1075,7 @@ class Writer(AbstractWriter):
                     hasattr(i, "connecting_element")
                     and i.connecting_element is not None
                 ):
-                    txt += " Bus1={elt}".format(elt=i.connecting_element)
+                    txt += " Bus1={elt}".format(elt=i.connecting_element.replace(".", "_").replace(" ", "_"))
                     if (
                         hasattr(i, "phase_storages")
                         and i.phase_storages is not None
@@ -1290,7 +1293,7 @@ class Writer(AbstractWriter):
                     and i.connecting_element is not None
                 ):
                     txt += " bus1={connecting_elt}".format(
-                        connecting_elt=i.connecting_element
+                        connecting_elt=i.connecting_element.replace(".", "_").replace(" ", "_")
                     )
                     if hasattr(i, "phases") and i.phases is not None:
                         for phase in i.phases:
@@ -1816,7 +1819,7 @@ class Writer(AbstractWriter):
                     hasattr(i, "connecting_element")
                     and i.connecting_element is not None
                 ):
-                    txt += " bus1={bus}".format(bus=i.connecting_element)
+                    txt += " bus1={bus}".format(bus=i.connecting_element.replace(".", "_").replace(" ", "_"))
                     if hasattr(i, "phase_loads") and i.phase_loads is not None:
                         for phase_load in i.phase_loads:
                             if (
@@ -2093,7 +2096,7 @@ class Writer(AbstractWriter):
                 if hasattr(i, "connected_transformer"):
 
                     # If we have a valid connected_transformer then job's easy...
-                    if i.connected_transformer is not None:
+                    if i.connected_transformer is not None:  # not setting the connected_transformer in reader parse_regulators
                         txt += " transformer={trans}".format(
                             trans=i.connected_transformer
                         )
@@ -2147,7 +2150,7 @@ class Writer(AbstractWriter):
                             and i.to_element is not None
                         ):
                             transfo_creation_string += " buses=({b1}.{p},{b2}.{p})".format(
-                                b1=i.from_element, b2=i.to_element, p=phase_string
+                                b1=i.from_element.replace(".","_").replace(" ", "_"), b2=i.to_element.replace(".","_").replace(" ", "_"), p=phase_string
                             )
 
                         # Conns
@@ -2249,8 +2252,8 @@ class Writer(AbstractWriter):
                                 )
                                 pass
                             # XLT:
-                            try:
-                                if isinstance(i.reactances[1], (int, float)):
+                            try: # probably an index error b/c cyme reader only has api_transformer.reactances = [float(xhl)]
+                                if isinstance(i.reactances[1], (int, float)):  
                                     transfo_creation_string += " XLT={}".format(
                                         i.reactances[1]
                                     )
@@ -2262,7 +2265,7 @@ class Writer(AbstractWriter):
                                 )
                                 pass
                             # XHT:
-                            try:
+                            try: # probably an index error b/c cyme reader only has api_transformer.reactances = [float(xhl)]
                                 if isinstance(i.reactances[2], (int, float)):
                                     transfo_creation_string += " XHT={}".format(
                                         i.reactances[2]
@@ -2500,7 +2503,7 @@ class Writer(AbstractWriter):
 
                 # Connecting element
                 if i.connecting_element is not None:
-                    txt += " Bus1=" + i.connecting_element
+                    txt += " Bus1=" + i.connecting_element.replace(".", "_").replace(" ", "_")
 
                     # For a 3-phase capbank we don't add any suffixes to the output.
                     if (
@@ -2838,7 +2841,7 @@ class Writer(AbstractWriter):
 
                 # from_element
                 if hasattr(i, "from_element") and i.from_element is not None:
-                    txt += " bus1={from_el}".format(from_el=i.from_element)
+                    txt += " bus1={from_el}".format(from_el=i.from_element.replace(".", "_").replace(" ", "_"))
                     if hasattr(i, "wires") and i.wires is not None:
                         for wire in i.wires:
                             if (
@@ -2850,7 +2853,7 @@ class Writer(AbstractWriter):
 
                 # to_element
                 if hasattr(i, "to_element") and i.to_element is not None:
-                    txt += " bus2={to_el}".format(to_el=i.to_element)
+                    txt += " bus2={to_el}".format(to_el=i.to_element.replace(".", "_").replace(" ", "_"))
                     if hasattr(i, "wires") and i.wires is not None:
                         for wire in i.wires:
                             if (
@@ -2913,7 +2916,7 @@ class Writer(AbstractWriter):
                 if i in lines_to_geometrify:
                     txt += " geometry={g}".format(g=i.nameclass)
                 elif i in lines_to_linecodify:
-                    txt += " Linecode={c}".format(c=i.nameclass)
+                    txt += " Linecode={c}".format(c=i.nameclass.replace(".","_").replace(" ", "_"))
 
                 txt += "\n\n"
                 if fuse_line != "":
@@ -3446,7 +3449,7 @@ class Writer(AbstractWriter):
                     )
 
                     for linecode_name, linecode_data in txt.items():
-                        fp.write("New Linecode.{name}".format(name=linecode_name))
+                        fp.write("New Linecode.{name}".format(name=linecode_name.replace(".","_").replace(" ", "_")))
                         for k, v in linecode_data.items():
                             fp.write(" {k}={v}".format(k=k, v=v))
                         fp.write("\n\n")
@@ -3753,7 +3756,7 @@ class Writer(AbstractWriter):
         with open(
             os.path.join(self.output_path, self.output_filenames["master"]), "w"
         ) as fp:
-            fp.write("Clear\n\nNew Circuit.Full_Network ")
+            fp.write("Clear\n\nNew Circuit.Full_Network ")  # not reached for PPL model? it is but gets overwritten?
             for obj in model.models:
                 if (
                     isinstance(obj, PowerSource) and obj.is_sourcebus == 1
@@ -3768,7 +3771,7 @@ class Writer(AbstractWriter):
                     ):
                         fp.write(
                             "bus1={name} pu={pu}".format(
-                                name=obj.connecting_element, pu=obj.per_unit
+                                name=obj.connecting_element.replace(".", "_").replace(" ", "_"), pu=obj.per_unit
                             )
                         )
                     else:
@@ -3779,7 +3782,7 @@ class Writer(AbstractWriter):
                         )
                         fp.write(
                             "bus1={name} pu={pu}".format(
-                                name=cleaned_name, pu=obj.per_unit
+                                name=cleaned_name.replace(".", "_").replace(" ", "_"), pu=obj.per_unit
                             )
                         )
 
@@ -3878,6 +3881,10 @@ class Writer(AbstractWriter):
                 )  # The buscoords are also written to base folder as well as the subfolders
 
             fp.write("\nSolve")
+
+        # return # below is opening Master.dss again !?
+
+
         for i in model.models:
             if isinstance(i, Node) and i.is_substation_connection:
                 feeder_name = i.feeder_name
@@ -3886,7 +3893,7 @@ class Writer(AbstractWriter):
                 substation_name = substation_name.replace(">", "-")
                 # Note that subtransmission has no substation_connection and hence doesn't have a master file, even though it does have other .dss files
                 if (
-                    feeder_name == "" and i.nominal_voltage < 30000
+                    feeder_name == "" #and i.nominal_voltage < 30000
                 ):  # A hack to deal with dangling feeders. TODO: Fix this in layerstack
                     continue
                 with open(
@@ -3918,7 +3925,7 @@ class Writer(AbstractWriter):
                         fp.write(
                             "Clear\n\nNew Circuit.feeder_{name} ".format(name=i.name)
                         )
-                    fp.write("bus1={name} pu={pu}".format(name=i.name, pu=i.setpoint))
+                    fp.write("bus1={name} pu={pu}".format(name=i.name.replace(".", "_").replace(" ", "_"), pu=i.setpoint))
                     if hasattr(i, "nominal_voltage") and i.nominal_voltage is not None:
                         fp.write(
                             " basekV={volt}".format(volt=i.nominal_voltage * 10 ** -3)
@@ -3953,7 +3960,7 @@ class Writer(AbstractWriter):
                             ]
                         )
                     else:
-                        _baseKV_list_ = []
+                        _baseKV_list_ = []  # getting here?
                     _baseKV_list_ = sorted(_baseKV_list_)
                     fp.write("\nSet Voltagebases={}\n".format(_baseKV_list_))
 

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -136,7 +136,7 @@ class Writer(AbstractWriter):
         d1 = ctx.create_decimal(repr(f))
         return format(d1, "f")
 
-    def write(self, model, **kwargs):
+    def write(self, model, write_taps=False, **kwargs):
         """General writing function responsible for calling the sub-functions.
 
         Note: re.sub('[^0-9a-zA-Z]+', '_', object_name) is used to fix node/bus names for OpenDSS, 
@@ -157,10 +157,7 @@ class Writer(AbstractWriter):
         else:
             self.verbose = False
 
-        if "write_taps" in kwargs:
-            self.write_taps = kwargs["write_taps"]
-        else:
-            self.write_taps = False
+        self.write_taps = write_taps
 
         if "separate_feeders" in kwargs:
             self.separate_feeders = kwargs["separate_feeders"]
@@ -764,8 +761,9 @@ class Writer(AbstractWriter):
 
                         for cnt, winding in enumerate(i.windings):
 
-                            txt += " wdg={N}".format(N=cnt + 1)
+                            txt += f" wdg={cnt+1}"
 
+                            # conn = wye or delta
                             if (
                                 hasattr(winding, "connection_type")
                                 and winding.connection_type is not None

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -7,6 +7,7 @@ import os
 import math
 import logging
 import decimal
+import re
 
 import numpy as np
 import pandas as pd
@@ -138,7 +139,7 @@ class Writer(AbstractWriter):
     def write(self, model, **kwargs):
         """General writing function responsible for calling the sub-functions.
 
-        Note: .replace(".","_").replace(" ", "_") are used to fix node/bus names for OpenDSS, 
+        Note: re.sub('[^0-9a-zA-Z]+', '_', object_name) is used to fix node/bus names for OpenDSS, 
             which uses dots for phase designation and spaces for paramater delimiters.
 
         :param model: DiTTo model
@@ -344,7 +345,7 @@ class Writer(AbstractWriter):
                         txt = feeder_text_map[substation_name + "_" + feeder_name]
 
                     txt += "{name} {X} {Y}\n".format(
-                        name=i.name.lower().replace(".","_").replace(" ", "_"), X=i.positions[0].long, Y=i.positions[0].lat
+                        name=re.sub('[^0-9a-zA-Z]+', '_', i.name.lower()), X=i.positions[0].long, Y=i.positions[0].lat
                     )
                     feeder_text_map[substation_name + "_" + feeder_name] = txt
 
@@ -681,7 +682,7 @@ class Writer(AbstractWriter):
 
                                 if buses is not None:
                                     bus = buses[cnt]
-                                    txt += " bus={bus}".format(bus=str(bus).replace(".","_").replace(" ", "_"))
+                                    txt += " bus={bus}".format(bus=re.sub('[^0-9a-zA-Z]+', '_', str(bus)))
 
                                 if len(winding.phase_windings) != 3:
 
@@ -784,9 +785,9 @@ class Writer(AbstractWriter):
                             if buses is not None:
 
                                 if cnt == 0 or cnt == 1:
-                                    txt += " bus={b}".format(b=buses[cnt].replace(".","_").replace(" ", "_"))
+                                    txt += " bus={b}".format(b=re.sub('[^0-9a-zA-Z]+', '_', buses[cnt]))
                                 elif cnt == 2:
-                                    txt += " bus={b}".format(b=buses[cnt - 1].replace(".","_").replace(" ", "_"))
+                                    txt += " bus={b}".format(b=re.sub('[^0-9a-zA-Z]+', '_', buses[cnt - 1]))
 
                                 # These are the configurations for center tap transformers
                                 if cnt == 0:
@@ -1075,7 +1076,7 @@ class Writer(AbstractWriter):
                     hasattr(i, "connecting_element")
                     and i.connecting_element is not None
                 ):
-                    txt += " Bus1={elt}".format(elt=i.connecting_element.replace(".", "_").replace(" ", "_"))
+                    txt += " Bus1={elt}".format(elt=re.sub('[^0-9a-zA-Z]+', '_', i.connecting_element))
                     if (
                         hasattr(i, "phase_storages")
                         and i.phase_storages is not None
@@ -1293,7 +1294,7 @@ class Writer(AbstractWriter):
                     and i.connecting_element is not None
                 ):
                     txt += " bus1={connecting_elt}".format(
-                        connecting_elt=i.connecting_element.replace(".", "_").replace(" ", "_")
+                        connecting_elt=re.sub('[^0-9a-zA-Z]+', '_', i.connecting_element)
                     )
                     if hasattr(i, "phases") and i.phases is not None:
                         for phase in i.phases:
@@ -1797,6 +1798,7 @@ class Writer(AbstractWriter):
                     substation_text_map[substation_name] = set([feeder_name])
                 else:
                     substation_text_map[substation_name].add(feeder_name)
+
                 txt = ""
                 if substation_name + "_" + feeder_name in feeder_text_map:
                     txt = feeder_text_map[substation_name + "_" + feeder_name]
@@ -1819,7 +1821,7 @@ class Writer(AbstractWriter):
                     hasattr(i, "connecting_element")
                     and i.connecting_element is not None
                 ):
-                    txt += " bus1={bus}".format(bus=i.connecting_element.replace(".", "_").replace(" ", "_"))
+                    txt += " bus1={bus}".format(bus=re.sub('[^0-9a-zA-Z]+', '_', i.connecting_element))
                     if hasattr(i, "phase_loads") and i.phase_loads is not None:
                         for phase_load in i.phase_loads:
                             if (
@@ -1985,6 +1987,7 @@ class Writer(AbstractWriter):
 
                 txt += "\n\n"
                 feeder_text_map[substation_name + "_" + feeder_name] = txt
+        
         for substation_name in substation_text_map:
             for feeder_name in substation_text_map[substation_name]:
                 txt = feeder_text_map[substation_name + "_" + feeder_name]
@@ -2150,7 +2153,7 @@ class Writer(AbstractWriter):
                             and i.to_element is not None
                         ):
                             transfo_creation_string += " buses=({b1}.{p},{b2}.{p})".format(
-                                b1=i.from_element.replace(".","_").replace(" ", "_"), b2=i.to_element.replace(".","_").replace(" ", "_"), p=phase_string
+                                b1=re.sub('[^0-9a-zA-Z]+', '_', i.from_element), b2=re.sub('[^0-9a-zA-Z]+', '_', i.to_element), p=phase_string
                             )
 
                         # Conns
@@ -2503,7 +2506,7 @@ class Writer(AbstractWriter):
 
                 # Connecting element
                 if i.connecting_element is not None:
-                    txt += " Bus1=" + i.connecting_element.replace(".", "_").replace(" ", "_")
+                    txt += " Bus1=" + re.sub('[^0-9a-zA-Z]+', '_', i.connecting_element)
 
                     # For a 3-phase capbank we don't add any suffixes to the output.
                     if (
@@ -2841,7 +2844,7 @@ class Writer(AbstractWriter):
 
                 # from_element
                 if hasattr(i, "from_element") and i.from_element is not None:
-                    txt += " bus1={from_el}".format(from_el=i.from_element.replace(".", "_").replace(" ", "_"))
+                    txt += " bus1={from_el}".format(from_el=re.sub('[^0-9a-zA-Z]+', '_', i.from_element)
                     if hasattr(i, "wires") and i.wires is not None:
                         for wire in i.wires:
                             if (
@@ -2853,7 +2856,7 @@ class Writer(AbstractWriter):
 
                 # to_element
                 if hasattr(i, "to_element") and i.to_element is not None:
-                    txt += " bus2={to_el}".format(to_el=i.to_element.replace(".", "_").replace(" ", "_"))
+                    txt += " bus2={to_el}".format(to_el=re.sub('[^0-9a-zA-Z]+', '_', i.to_element)
                     if hasattr(i, "wires") and i.wires is not None:
                         for wire in i.wires:
                             if (
@@ -2916,7 +2919,7 @@ class Writer(AbstractWriter):
                 if i in lines_to_geometrify:
                     txt += " geometry={g}".format(g=i.nameclass)
                 elif i in lines_to_linecodify:
-                    txt += " Linecode={c}".format(c=i.nameclass.replace(".","_").replace(" ", "_"))
+                    txt += " Linecode={c}".format(c=re.sub('[^0-9a-zA-Z]+', '_', i.nameclass)
 
                 txt += "\n\n"
                 if fuse_line != "":
@@ -3449,7 +3452,7 @@ class Writer(AbstractWriter):
                     )
 
                     for linecode_name, linecode_data in txt.items():
-                        fp.write("New Linecode.{name}".format(name=linecode_name.replace(".","_").replace(" ", "_")))
+                        fp.write("New Linecode.{name}".format(name=re.sub('[^0-9a-zA-Z]+', '_', linecode_name)))
                         for k, v in linecode_data.items():
                             fp.write(" {k}={v}".format(k=k, v=v))
                         fp.write("\n\n")
@@ -3771,7 +3774,7 @@ class Writer(AbstractWriter):
                     ):
                         fp.write(
                             "bus1={name} pu={pu}".format(
-                                name=obj.connecting_element.replace(".", "_").replace(" ", "_"), pu=obj.per_unit
+                                name=re.sub('[^0-9a-zA-Z]+', '_', obj.connecting_element), pu=obj.per_unit
                             )
                         )
                     else:
@@ -3782,7 +3785,7 @@ class Writer(AbstractWriter):
                         )
                         fp.write(
                             "bus1={name} pu={pu}".format(
-                                name=cleaned_name.replace(".", "_").replace(" ", "_"), pu=obj.per_unit
+                                name=re.sub('[^0-9a-zA-Z]+', '_', cleaned_name), pu=obj.per_unit
                             )
                         )
 
@@ -3925,7 +3928,7 @@ class Writer(AbstractWriter):
                         fp.write(
                             "Clear\n\nNew Circuit.feeder_{name} ".format(name=i.name)
                         )
-                    fp.write("bus1={name} pu={pu}".format(name=i.name.replace(".", "_").replace(" ", "_"), pu=i.setpoint))
+                    fp.write("bus1={name} pu={pu}".format(name=re.sub('[^0-9a-zA-Z]+', '_', i.name), pu=i.setpoint))
                     if hasattr(i, "nominal_voltage") and i.nominal_voltage is not None:
                         fp.write(
                             " basekV={volt}".format(volt=i.nominal_voltage * 10 ** -3)

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -3794,6 +3794,7 @@ class Writer(AbstractWriter):
                         fp.write(
                             " basekV={volt}".format(volt=obj.nominal_voltage * 10 ** -3)
                         )  # DiTTo in volts
+                        self._baseKV_.add(obj.nominal_voltage * 10 ** -3)
 
                     if (
                         hasattr(obj, "positive_sequence_impedance")

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -599,6 +599,14 @@ class Writer(AbstractWriter):
 
                             # Voltage type (Not mapped)
 
+                            # volage basis
+                            if (
+                                hasattr(winding, "base_voltage")
+                                and winding.base_voltage is not None
+                                and winding.base_voltage > 0
+                            ):
+                                self._baseKV_.add(winding.base_voltage * 10 ** -3)
+
                             # Nominal voltage
                             if (
                                 hasattr(winding, "nominal_voltage")

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -1387,7 +1387,7 @@ class Writer(AbstractWriter):
                     )  # DiTTo in watts
 
                 if hasattr(i, "reactive_rating") and i.reactive_rating is not None:
-                    txt += " kvarlimit={kvar}".format(
+                    txt += " kvarmax={kvar}".format(
                         kvar=i.reactive_rating
                         * 10
                         ** -3  # Set the inverter to be oversized by 10% if active rating not specified

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -2844,7 +2844,7 @@ class Writer(AbstractWriter):
 
                 # from_element
                 if hasattr(i, "from_element") and i.from_element is not None:
-                    txt += " bus1={from_el}".format(from_el=re.sub('[^0-9a-zA-Z]+', '_', i.from_element)
+                    txt += " bus1={from_el}".format(from_el=re.sub('[^0-9a-zA-Z]+', '_', i.from_element))
                     if hasattr(i, "wires") and i.wires is not None:
                         for wire in i.wires:
                             if (
@@ -2856,7 +2856,7 @@ class Writer(AbstractWriter):
 
                 # to_element
                 if hasattr(i, "to_element") and i.to_element is not None:
-                    txt += " bus2={to_el}".format(to_el=re.sub('[^0-9a-zA-Z]+', '_', i.to_element)
+                    txt += " bus2={to_el}".format(to_el=re.sub('[^0-9a-zA-Z]+', '_', i.to_element))
                     if hasattr(i, "wires") and i.wires is not None:
                         for wire in i.wires:
                             if (
@@ -2919,7 +2919,7 @@ class Writer(AbstractWriter):
                 if i in lines_to_geometrify:
                     txt += " geometry={g}".format(g=i.nameclass)
                 elif i in lines_to_linecodify:
-                    txt += " Linecode={c}".format(c=re.sub('[^0-9a-zA-Z]+', '_', i.nameclass)
+                    txt += " Linecode={c}".format(c=re.sub('[^0-9a-zA-Z]+', '_', i.nameclass))
 
                 txt += "\n\n"
                 if fuse_line != "":

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -3765,7 +3765,7 @@ class Writer(AbstractWriter):
         with open(
             os.path.join(self.output_path, self.output_filenames["master"]), "w"
         ) as fp:
-            fp.write("Clear\n\nNew Circuit.Full_Network ")  # not reached for PPL model? it is but gets overwritten?
+            fp.write("Clear\n\nNew Circuit.Full_Network ")
             for obj in model.models:
                 if (
                     isinstance(obj, PowerSource) and obj.is_sourcebus == 1
@@ -3970,7 +3970,7 @@ class Writer(AbstractWriter):
                             ]
                         )
                     else:
-                        _baseKV_list_ = []  # getting here?
+                        _baseKV_list_ = []
                     _baseKV_list_ = sorted(_baseKV_list_)
                     fp.write("\nSet Voltagebases={}\n".format(_baseKV_list_))
 

--- a/ditto/writers/opendss/write.py
+++ b/ditto/writers/opendss/write.py
@@ -169,7 +169,6 @@ class Writer(AbstractWriter):
             self.separate_substations = False
 
         # Write the bus coordinates
-        logger.info("Writing the bus coordinates...")
         if self.verbose:
             logger.debug("Writing the bus coordinates...")
         s = self.write_bus_coordinates(model)
@@ -177,7 +176,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the transformers
-        logger.info("Writing the transformers...")
         if self.verbose:
             logger.debug("Writing the transformers...")
         s = self.write_transformers(model)
@@ -185,7 +183,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the regulators
-        logger.info("Writing the regulators...")
         if self.verbose:
             logger.debug("Writing the regulators...")
         s = self.write_regulators(model)
@@ -193,7 +190,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # write the timeseries
-        logger.info("Writing the timeseries...")
         if self.verbose:
             logger.debug("Writing the timeseries...")
         s = self.write_timeseries(model)
@@ -201,7 +197,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # write the loads
-        logger.info("Writing the loads...")
         if self.verbose:
             logger.debug("Writing the loads...")
         s = self.write_loads(model)
@@ -209,7 +204,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the lines
-        logger.info("Writting the lines...")
         if self.verbose:
             logger.debug("Writting the lines...")
         s = self.write_lines(model)
@@ -217,7 +211,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the capacitors
-        self.logger.info("Writing the capacitors...")
         if self.verbose:
             logger.debug("Writing the capacitors...")
         s = self.write_capacitors(model)
@@ -225,7 +218,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the storage elements
-        logger.info("Writting the storage devices...")
         if self.verbose:
             logger.debug("Writting the storage devices...")
         s = self.write_storages(model)
@@ -233,7 +225,6 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the PV
-        logger.info("Writting the PVs...")
         if self.verbose:
             logger.debug("Writting the PVs...")
         s = self.write_PVs(model)
@@ -241,14 +232,12 @@ class Writer(AbstractWriter):
             logger.debug("Succesful!")
 
         # Write the Master file
-        logger.info("Writting the master file...")
         if self.verbose:
             logger.debug("Writting the master file...")
         s = self.write_master_file(model)
         if self.verbose and s != -1:
             logger.debug("Succesful!")
 
-        logger.info("Done.")
         if self.verbose:
             logger.debug("Writting done.")
 


### PR DESCRIPTION
currently the opendss writer sums up all phase loads to place them on a bus (which implies that loads are balanced equally on each phase at each bus):
https://github.com/NREL/ditto/blob/8d0d7a5ddf71532d6d716b617dc57f84d810d7ea/ditto/writers/opendss/write.py#L1887-L1890
this PR allows for defining individual phase loads by creating `New Load` for each `PhaseLoad`.