### PR TITLE
More strict dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ numpy_dependency = "numpy~=1.20"
 
 extras_requires = [
     "lxml~=4.9",
-    "pandas~=2.0",
+    "pandas~=1.3.5", # Pyton 3.7 does not support pandas 1.4
     "scipy~=1.7",
     numpy_dependency,
     "XlsxWriter~=3.0",
@@ -123,7 +123,7 @@ setup(
         "six~=1.16",
         "traitlets~=5.1,<5.10",
         "json_tricks~=3.16",
-        "pandas",
+        "pandas~=1.3.5",
         numpy_dependency,
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ setup(
         "future~=0.18",
         "networkx~=2.5",
         "six~=1.16",
-        "traitlets~=5.1,<5.10",
+        "traitlets~=5.1",
         "json_tricks~=3.16",
         "pandas~=1.3.5",
         numpy_dependency,

--- a/setup.py
+++ b/setup.py
@@ -27,33 +27,33 @@ with open(os.path.join(here, "ditto", "version.py"), encoding="utf-8") as f:
 version = version.splitlines()[1].split()[2].strip('"').strip("'")
 
 test_requires = [
-    "backports.tempfile>=1.0",
-    "pytest>=7.0.1",
-    "pytest-cov>=4.0.0",
-    "sphinx-rtd-theme>=1.1.1",
-    "nbsphinx>=0.8.10",
-    "sphinxcontrib-napoleon>=0.7",
-    "ghp-import>=2.1.0",
+    "backports.tempfile~=1.0",
+    "pytest~=7.4",
+    "pytest-cov~=4.0",
+    "sphinx-rtd-theme~=1.1",
+    "nbsphinx~=0.8",
+    "sphinxcontrib-napoleon~=0.7",
+    "ghp-import~=2.1",
 ]
 
-numpy_dependency = "numpy>=1.20.0"
+numpy_dependency = "numpy~=1.20"
 
 extras_requires = [
-    "lxml>=4.9.1",
-    "pandas",
-    "scipy>=1.7.3",
+    "lxml~=4.9",
+    "pandas~=2.0",
+    "scipy~=1.7",
     numpy_dependency,
-    "XlsxWriter>=3.0.3",
+    "XlsxWriter~=3.0",
 ]
 
-opendss_requires = ["OpenDSSDirect.py>=0.7.0", "pandas", numpy_dependency]
-dew_requires = [numpy_dependency, "xlrd>=2.0.1"]
-gridlabd_requires = ["croniter>=1.3.7", numpy_dependency]
+opendss_requires = ["OpenDSSDirect.py~=0.7", "pandas", numpy_dependency]
+dew_requires = [numpy_dependency, "xlrd~=2.0"]
+gridlabd_requires = ["croniter~=1.3", numpy_dependency]
 cyme_requires = [numpy_dependency]
 ephasor_requires = [numpy_dependency, "pandas"]
 synergi_requires = [
     numpy_dependency,
-    "pandas_access>=0.0.1",
+    "pandas_access~=0.0",
 ]  # Need pandas_access to convert the MDB tables to Pandas DataFrame
 windmil_requires = ["bokeh", "xmltodict"]
 
@@ -117,12 +117,12 @@ setup(
     ],
     test_suite="tests",
     install_requires=[
-        "click>=8.0.4",
-        "future>=0.18.2",
-        "networkx>=2.5.1",
-        "six>=1.16.0",
-        "traitlets>=5.1.1",
-        "json_tricks>=3.16.1",
+        "click~=8.0",
+        "future~=0.18",
+        "networkx~=2.5",
+        "six~=1.16",
+        "traitlets~=5.1,<5.10",
+        "json_tricks~=3.16",
         "pandas",
         numpy_dependency,
     ],


### PR DESCRIPTION
Use [compatible release](https://peps.python.org/pep-0440/#compatible-release) (tilde-style) versioning for dependencies. Assuming the maintainers of the dependencies use [semantic versioning](https://semver.org/) this will prevent backwards-incompatible changes from being unexpectedly introduced, while still getting updates that are compatible with what currently works.

I added an additional constraint to the traitlets dependency, which satisfies option 1 of https://github.com/NREL/ditto/issues/426. However, option 3 is my preferred solution, which would allow for the removal of the second version constraint on traitlets. I submitted a separate PR https://github.com/NREL/ditto/pull/429 for that change.