### PR TITLE
Remove unused imports from traitlets

### DIFF
--- a/ditto/models/base.py
+++ b/ditto/models/base.py
@@ -4,8 +4,6 @@ from builtins import super, range, zip, round, map
 
 import warnings
 from traitlets.traitlets import (
-    ObserveHandler,
-    _deprecated_method,
     _CallbackWrapper,
     EventHandler,
 )


### PR DESCRIPTION
Resolves #426 

2 methods were being imported from traitlets that are unused. Removing them reduces the risk surface, enabling a more stable package.

If these are actually required, please let me know where they are used and I will close this PR.